### PR TITLE
Rename config variables: RESTPLUS_* -> RESTX_*

### DIFF
--- a/doc/mask.rst
+++ b/doc/mask.rst
@@ -5,7 +5,7 @@ Flask-RESTX support partial object fetching (aka. fields mask)
 by supplying a custom header in the request.
 
 By default the header is ``X-Fields``
-but it can be changed with the ``RESTPLUS_MASK_HEADER`` parameter.
+but it can be changed with the ``RESTX_MASK_HEADER`` parameter.
 
 Syntax
 ------
@@ -65,7 +65,7 @@ The header will be exposed as a Swagger parameter each time you use the
 
 As Swagger does not permit exposing a global header once
 it can make your Swagger specifications a lot more verbose.
-You can disable this behavior by setting ``RESTPLUS_MASK_SWAGGER`` to ``False``.
+You can disable this behavior by setting ``RESTX_MASK_SWAGGER`` to ``False``.
 
 You can also specify a default mask that will be applied if no header mask is found.
 

--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -125,7 +125,7 @@ The ``@api.expect()`` decorator
 The ``@api.expect()`` decorator allows you to specify the expected input fields.
 It accepts an optional boolean parameter ``validate`` indicating whether the payload should be validated.
 The validation behavior can be customized globally either
-by setting the ``RESTPLUS_VALIDATE`` configuration to ``True``
+by setting the ``RESTX_VALIDATE`` configuration to ``True``
 or passing ``validate=True`` to the API constructor.
 
 The following examples are equivalent:
@@ -215,7 +215,7 @@ An example of application-wide validation by config:
 
 .. code-block:: python
 
-    app.config['RESTPLUS_VALIDATE'] = True
+    app.config['RESTX_VALIDATE'] = True
 
     api = Api(app)
 

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -215,9 +215,9 @@ class Api(object):
             self._configure_namespace_logger(app, ns)
 
         self._register_apidoc(app)
-        self._validate = self._validate if self._validate is not None else app.config.get('RESTPLUS_VALIDATE', False)
-        app.config.setdefault('RESTPLUS_MASK_HEADER', 'X-Fields')
-        app.config.setdefault('RESTPLUS_MASK_SWAGGER', True)
+        self._validate = self._validate if self._validate is not None else app.config.get('RESTX_VALIDATE', False)
+        app.config.setdefault('RESTX_MASK_HEADER', 'X-Fields')
+        app.config.setdefault('RESTX_MASK_SWAGGER', True)
 
     def __getattr__(self, name):
         try:

--- a/flask_restx/marshalling.py
+++ b/flask_restx/marshalling.py
@@ -247,7 +247,7 @@ class marshal_with(object):
             resp = f(*args, **kwargs)
             mask = self.mask
             if has_app_context():
-                mask_header = current_app.config['RESTPLUS_MASK_HEADER']
+                mask_header = current_app.config['RESTX_MASK_HEADER']
                 mask = request.headers.get(mask_header) or mask
             if isinstance(resp, tuple):
                 data, code, headers = unpack(resp)

--- a/flask_restx/representations.py
+++ b/flask_restx/representations.py
@@ -12,7 +12,7 @@ from flask import make_response, current_app
 def output_json(data, code, headers=None):
     '''Makes a Flask response with a JSON encoded body'''
 
-    settings = current_app.config.get('RESTPLUS_JSON', {})
+    settings = current_app.config.get('RESTX_JSON', {})
 
     # If we're in debug mode, and the indent is not set, we set it to a
     # reasonable value here.  Note that this won't override any existing value

--- a/flask_restx/resource.py
+++ b/flask_restx/resource.py
@@ -12,7 +12,7 @@ from .utils import unpack
 
 class Resource(MethodView):
     '''
-    Represents an abstract RESTPlus resource.
+    Represents an abstract RESTX resource.
 
     Concrete resources should extend from this class
     and expose methods for each supported HTTP method.

--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -468,9 +468,9 @@ class Swagger(object):
 
         # Handle fields mask
         mask = doc.get('__mask__')
-        if (mask and current_app.config['RESTPLUS_MASK_SWAGGER']):
+        if (mask and current_app.config['RESTX_MASK_SWAGGER']):
             param = {
-                'name': current_app.config['RESTPLUS_MASK_HEADER'],
+                'name': current_app.config['RESTX_MASK_HEADER'],
                 'in': 'header',
                 'type': 'string',
                 'format': 'mask',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ class TestClient(FlaskClient):
         return json.loads(response.data.decode('utf8'))
 
     def get_specs(self, prefix='', status=200, **kwargs):
-        '''Get a Swagger specification for a RestPlus API'''
+        '''Get a Swagger specification for a RESTX API'''
         return self.get_json('{0}/swagger.json'.format(prefix), status=status, **kwargs)
 
 

--- a/tests/legacy/test_api_legacy.py
+++ b/tests/legacy/test_api_legacy.py
@@ -318,9 +318,11 @@ class APITest(object):
 
     def test_read_json_settings_from_config(self, app, client):
         class TestConfig(object):
-            RESTPLUS_JSON = {'indent': 2,
-                             'sort_keys': True,
-                             'separators': (', ', ': ')}
+            RESTX_JSON = {
+                'indent': 2,
+                'sort_keys': True,
+                'separators': (', ', ': ')
+            }
 
         app.config.from_object(TestConfig)
         api = restx.Api(app)
@@ -343,7 +345,7 @@ class APITest(object):
                 return 'cabbage'
 
         class TestConfig(object):
-            RESTPLUS_JSON = {'cls': CabageEncoder}
+            RESTX_JSON = {'cls': CabageEncoder}
 
         app.config.from_object(TestConfig)
         api = restx.Api(app)

--- a/tests/test_fields_mask.py
+++ b/tests/test_fields_mask.py
@@ -757,7 +757,7 @@ class MaskAPI(object):
                     'boolean': True
                 }
 
-        app.config['RESTPLUS_MASK_HEADER'] = 'X-Mask'
+        app.config['RESTX_MASK_HEADER'] = 'X-Mask'
         data = client.get_json('/test/', headers={'X-Mask': '{name,age}'})
 
         assert data == {'name': 'John Doe', 'age': 42}
@@ -963,7 +963,7 @@ class SwaggerMaskHeaderTest(object):
                     'boolean': True
                 }
 
-        app.config['RESTPLUS_MASK_HEADER'] = 'X-Mask'
+        app.config['RESTX_MASK_HEADER'] = 'X-Mask'
         specs = client.get_specs()
 
         op = specs['paths']['/test/']['get']
@@ -992,7 +992,7 @@ class SwaggerMaskHeaderTest(object):
                     'boolean': True
                 }
 
-        app.config['RESTPLUS_MASK_SWAGGER'] = False
+        app.config['RESTX_MASK_SWAGGER'] = False
         specs = client.get_specs()
 
         op = specs['paths']['/test/']['get']

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -110,7 +110,7 @@ class PayloadTest(object):
         assert 'ipv4' in out['errors']['ip']
 
     def test_validation_false_in_config(self, app, client):
-        app.config['RESTPLUS_VALIDATE'] = False
+        app.config['RESTX_VALIDATE'] = False
         api = restx.Api(app)
 
         fields = api.model('Person', {
@@ -132,7 +132,7 @@ class PayloadTest(object):
         assert out == {}
 
     def test_validation_in_config(self, app, client):
-        app.config['RESTPLUS_VALIDATE'] = True
+        app.config['RESTX_VALIDATE'] = True
         api = restx.Api(app)
 
         fields = api.model('Person', {


### PR DESCRIPTION
Addresses https://github.com/python-restx/flask-restx/issues/8

Flask configuration variables were missed (my fault) in https://github.com/python-restx/flask-restx/pull/2. This PR renames these and should *hopefully* be the last of the renaming required (therefore closing https://github.com/python-restx/flask-restx/issues/1) !



