### PR TITLE
allow travis to push releases on PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,33 @@
 language: python
-
 python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8'
   - pypy
   - pypy3
-
-matrix:
-  include:
-    - python: 3.8-dev
-      dist: xenial
+jobs:
   allow_failures:
     - python: pypy3
-    - python: 3.8-dev
-
+    - python: '3.8'
 install:
   - pip install .[dev]
-
 script:
   - inv cover qa
-
 after_success:
   - pip install coveralls
   - coveralls --rcfile=coverage.rc
-  - ./travis-bench-after-success.sh
+  - "./travis-bench-after-success.sh"
+before_deploy:
+  - inv assets
+deploy:
+  provider: pypi
+  user: "__token__"
+  password:
+    secure: Bhk0mw7iFn+kan/rBdegQe2gbvtTd12hCxZzHwZCCgyu6xCK4UT/6eW6KucT1BP5sOzCteYzRcdg5PBLLwXaKXuSVtGmdZwmQcVRgWuXCA9/9YdPJSCSO3dHoVYpiXP9Tc72qPVi/Wwj9t2U7V8IcGoH4NDJn8XM2dFSYHm/ZhXQCSBcXLjLx7EI1M7yXo4h3tLfEka9+VZ8jdEsP6NATaJIeBqo4X4hZj2n2ux6Q0CyxqQWsTx0iQUsKrML7a5lE9vz7Mk21NkZLb8LAg3lRrYEyC2rIdhXOxDED410MGpwMQDZ8MUF85vB1ri/EFLfcRvbFs8+W0vrqltmABlwoymvmtw4B/lbRyjmArjYKk8CCeK5z5KVx+QICrxXMEG/4CeS5vQCz/0uB+Fzu0Xv44kslOSaFewwow/arke80WzdzecBzAi+HANb1L7hufRb63tkmf0Uz3JX5HplI31FbT/pQoL1pZtFoHC9u3/iqYY39z/3Jv8+gop5ZX1WaIgxBxfCIVqx//p3pq9LYkI8zdFv54tD8UiKKJiwAzMIrYQJLkB5RtKBYxoyBXOdYb0H9vVWISXcwQVuKJiQWO/GDjE1KX3TApHSz73DqMemuG5BYDCf9qIbm49rYY57NyFNvgLJVZCwgrY5J9Otmk+e5sjGo3wkOWOriAO6QH7RqEI=
+  on:
+    tags: true
+  skip_existing: true
+  skip_cleanup: true

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,9 +1,9 @@
 Contributing
 ============
 
-flask-restx is open-source and very open to contributions. 
+flask-restx is open-source and very open to contributions.
 
-If you're part of a corporation with an NDA, and you may require updating the license. 
+If you're part of a corporation with an NDA, and you may require updating the license.
 See Updating Copyright below
 
 Submitting issues
@@ -35,7 +35,7 @@ If you want to contribute some code:
 7. add your change to the changelog
 8. submit your pull-request
 9. 2 Maintainers should review the code for bugfix and features. 1 maintainer for minor changes (such as docs)
-10. After review, a maintainer a will merge the PR. Maintainers should not merge their own PRs 
+10. After review, a maintainer a will merge the PR. Maintainers should not merge their own PRs
 
 There are some rules to follow:
 
@@ -103,9 +103,15 @@ For local development, you may wish to run a local server. running the following
 
     $ inv assets
 
-NOTE: You'll need `NPM <https://docs.npmjs.com/getting-started/>`_ installed to do this. 
+NOTE: You'll need `NPM <https://docs.npmjs.com/getting-started/>`_ installed to do this.
 If you're new to NPM, also check out `nvm <https://github.com/creationix/nvm/blob/master/README.md>`_
 
+Release process
+---------------
+
+The new releases are pushed on `Pypi.org <https://pypi.org/>`_ automatically
+from `travis-ci <https://travis-ci.org/>`_ when we add a new tag (unless the
+tests are failing).
 
 Updating Copyright
 ------------------

--- a/bumpr.rc
+++ b/bumpr.rc
@@ -5,9 +5,6 @@ commit = true
 tag = true
 push = true
 tests = tox
-publish =
-    inv assets
-    python setup.py sdist bdist_wheel upload
 clean =
     inv clean
 files =

--- a/flask_restx/__about__.py
+++ b/flask_restx/__about__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.13.1.dev'
+__version__ = '0.0.1.dev0'
 __description__ = 'Fully featured framework for fast, easy and documented API development with Flask'


### PR DESCRIPTION
addresses #6 

Added a token in travis-ci to allow to push releases on PyPi.

I'll need to push a tag in order to test everything is working as expected.