### PR TITLE
[Feature] Allow users to set default model rendering of API docs

### DIFF
--- a/flask_restx/templates/swagger-ui.html
+++ b/flask_restx/templates/swagger-ui.html
@@ -66,6 +66,9 @@
                 {% if config.SWAGGER_SUPPORTED_SUBMIT_METHODS is defined -%}
                   supportedSubmitMethods: {{ config.SWAGGER_SUPPORTED_SUBMIT_METHODS | tojson}},
                 {%- endif %}
+                {% if config.SWAGGER_DEFAULT_MODEL_RENDERING is defined -%}
+                    defaultModelRendering: {{ config.SWAGGER_DEFAULT_MODEL_RENDERING | tojson}},
+                {%- endif %}
                 displayOperationId: {{ config.SWAGGER_UI_OPERATION_ID|default(False)|tojson }},
                 displayRequestDuration: {{ config.SWAGGER_UI_REQUEST_DURATION|default(False)|tojson }},
                 docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"


### PR DESCRIPTION
Add support for checking value of `app.config.SWAGGER_DEFAULT_MODEL_RENDERING`
and set `defaultModelRendering` parameter (Controls how the model is
shown when the API is first rendered).

Related issue #13 