### PR TITLE
register nested model wildcard fields in docs

### DIFF
--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -598,7 +598,7 @@ class Swagger(object):
                 self.register_model(model)
         elif isinstance(field, fields.Nested):
             self.register_model(field.nested)
-        elif isinstance(field, fields.List):
+        elif isinstance(field, (fields.List, fields.Wildcard)):
             self.register_field(field.container)
 
     def security_for(self, doc, method):


### PR DESCRIPTION
The new(ish) Wildcard field does not get registered in the docs because it isn't checked for when registering fields. This PR is a monkeypatch I have been using, but I think it is the correct behaviour.