### PR TITLE
Remove deprecated werkzeug import

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -21,7 +21,7 @@ from flask.signals import got_request_exception
 
 from jsonschema import RefResolver
 
-from werkzeug import cached_property
+from werkzeug.utils import cached_property
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError
 from werkzeug.wrappers import BaseResponse

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,7 +1,7 @@
 aniso8601>=0.82
 jsonschema
 Flask>=0.8
-werkzeug<=0.16.1
+werkzeug
 pytz
 six>=1.3.0
 enum34; python_version < '3.4'

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -5,7 +5,7 @@ pytest==4.6.5; python_version < '3.5'
 pytest==5.0.1; python_version >= '3.5'
 pytest-benchmark==3.2.2
 pytest-cov==2.7.1
-pytest-flask==0.15.0
+pytest-flask==0.15.1
 pytest-mock==1.10.4
 pytest-profiling==1.7.0
 pytest-sugar==0.9.2

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -413,7 +413,7 @@ class ErrorsTest(object):
 
         response = client.get("/foo")
         assert response.status_code == 404
-        assert response.headers['Content-Type'] == 'text/html'
+        assert response.headers['Content-Type'] == 'text/html; charset=utf-8'
 
     def test_non_api_error_404_catchall(self, app, client):
         api = restx.Api(app, catch_all_404s=True)


### PR DESCRIPTION
Fixes: #34

This import breaks with werkzeug 1.0. 

Before 1.0, werkzeug was generating this warning: 
> DeprecationWarning: The import 'werkzeug.cached_property' is deprecated and will be removed in Werkzeug 1.0. Use 'from werkzeug.utils import cached_property' instead.