### PR TITLE
fix: enforce werkzeug <= 0.16.1 until we get a proper fix

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,6 +1,7 @@
 aniso8601>=0.82
 jsonschema
 Flask>=0.8
+werkzeug<=0.16.1
 pytz
 six>=1.3.0
 enum34; python_version < '3.4'


### PR DESCRIPTION
This is a hotfix for #34 until we have a proper fix.