### PR TITLE
Use Coveralls GitHub Action instead of coveralls CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,10 @@ jobs:
       - name: Test with inv
         run: inv cover qa
       - name: Coveralls
-        run: |
-          pip install coveralls
-          coveralls --rcfile=coverage.rc
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: .coverage
   bench:
     needs: test
     runs-on: ubuntu-latest

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -25,7 +25,7 @@ from flask.signals import got_request_exception
 
 from jsonschema import RefResolver
 
-from werkzeug import cached_property
+from werkzeug.utils import cached_property
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound, NotAcceptable, InternalServerError
 from werkzeug.wrappers import BaseResponse

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -5,7 +5,7 @@ pytest==4.6.5; python_version < '3.5'
 pytest==5.0.1; python_version >= '3.5'
 pytest-benchmark==3.2.2
 pytest-cov==2.7.1
-pytest-flask==0.15.0
+pytest-flask==0.15.1
 pytest-mock==1.10.4
 pytest-profiling==1.7.0
 pytest-sugar==0.9.2

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -413,7 +413,7 @@ class ErrorsTest(object):
 
         response = client.get("/foo")
         assert response.status_code == 404
-        assert response.headers['Content-Type'] == 'text/html'
+        assert response.headers['Content-Type'] == 'text/html; charset=utf-8'
 
     def test_non_api_error_404_catchall(self, app, client):
         api = restx.Api(app, catch_all_404s=True)


### PR DESCRIPTION
Coveralls CLI requires a GITHUB_REPO_TOKEN env var for authentication.
This is set using GitHub secrets which are *not* available to forked
repos - causing the builds to fail on pull requests. The GitHub action
instead uses the built it GitHub Actions GITHUB_TOKEN which is available
to forked repos.