### PR TITLE
Run coveralls using travis for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Test with inv
         run: inv cover qa
       - name: Coveralls
+        if: github.repository == 'python-restx/flask-restx' && github.event == 'push'
         run: |
           pip install coveralls
           coveralls --rcfile=coverage.rc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python: "3.8"
+if: type = pull_request
+install:
+  - pip install ".[dev]" coveralls
+script:
+  - inv cover
+after_success:
+  - coveralls --rcfile=coverage.rc


### PR DESCRIPTION
Skipping the Coveralls step if action is run in a fork repo in the GitHub Actions
Using Travis to run the coveralls for PRs

Example: https://github.com/SVilgelm/flask-restx/runs/433679573?check_suite_focus=true

It's temporary solution until the https://github.com/codecov/codecov-action/issues/29 is resolved