### PR TITLE
Audit Python packages for known vulnerabilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ".[dev]"
+      - name: Audit Python packages for known vulnerabilities
+        run: |
+          if ! RES=$(ossaudit --installed --config setup.cfg); then
+            RES="${RES//'%'/'%25'}"
+            RES="${RES//$'\n'/'%0A'}"
+            RES="${RES//$'\r'/'%0D'}"
+            echo "::error ::${RES}"
+            exit 1
+          fi
+          echo ${RES}
       - name: Format with black
         run: |
           if ! RES=$(black --check $(git diff --name-only --diff-filter=AM master -- "*.py") 2>&1); then

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -10,7 +10,7 @@ pytest-mock==1.10.4
 pytest-profiling==1.7.0
 pytest-sugar==0.9.2
 tzlocal
-
 invoke==1.3.0
 readme-renderer==24.0
 twine==1.15.0
+ossaudit; python_version >= '3.5'

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,11 @@ python_classes = *Test *Benchmark
 markers =
     api: test requiring an initialized API
     request_context: switch the request
+
+[ossaudit]
+
+# The issue is fixed since the v40.8.0 of setuptools, but 
+# the python3.5 and python3.6 use the old versions.
+# https://ossindex.sonatype.org/vuln/06e60262-8241-42ef-8f64-e3d72091de19
+# Ignore it until we suppor python < 3.7
+ignore-ids = 06e60262-8241-42ef-8f64-e3d72091de19


### PR DESCRIPTION
Use [ossaudit](https://github.com/illikainen/ossaudit) to audit the installed packages.
The ossaudit supports python versions >= 3.5, so the workflow skips the audition for py27 and pypy2.
Partially implements #29 