### PR TITLE
Avoid DeprecationWarning when importing OrderedDict

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -10,11 +10,7 @@ import re
 import six
 import sys
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from functools import wraps, partial
 from types import MethodType
 

--- a/flask_restx/marshalling.py
+++ b/flask_restx/marshalling.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from functools import wraps
 from six import iteritems
 

--- a/flask_restx/mask.py
+++ b/flask_restx/mask.py
@@ -5,11 +5,7 @@ import logging
 import re
 import six
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from inspect import isclass
 
 from .errors import RestError

--- a/flask_restx/model.py
+++ b/flask_restx/model.py
@@ -5,11 +5,12 @@ import copy
 import re
 import warnings
 
+from collections import OrderedDict
 try:
-    from collections.abc import OrderedDict, MutableMapping
+    from collections.abc import MutableMapping
 except ImportError:
     # TODO Remove this to drop Python2 support
-    from collections import OrderedDict, MutableMapping
+    from collections import MutableMapping
 from six import iteritems, itervalues
 from werkzeug.utils import cached_property
 

--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -5,11 +5,12 @@ import itertools
 import re
 
 from inspect import isclass, getdoc
+from collections import OrderedDict
 try:
-    from collections.abc import OrderedDict, Hashable
+    from collections.abc import Hashable
 except ImportError:
     # TODO Remove this to drop Python2 support
-    from collections import OrderedDict, Hashable
+    from collections import Hashable
 from six import string_types, itervalues, iteritems, iterkeys
 
 from flask import current_app

--- a/flask_restx/utils.py
+++ b/flask_restx/utils.py
@@ -3,11 +3,7 @@ from __future__ import unicode_literals
 
 import re
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from copy import deepcopy
 from six import iteritems
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from datetime import date, datetime
 from decimal import Decimal
 from functools import partial

--- a/tests/test_fields_mask.py
+++ b/tests/test_fields_mask.py
@@ -4,11 +4,7 @@ from __future__ import unicode_literals
 import json
 import pytest
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 
 from flask_restx import mask, Api, Resource, fields, marshal, Mask
 

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -7,11 +7,7 @@ from flask_restx import (
     marshal, marshal_with, marshal_with_field, fields, Api, Resource
 )
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 
 
 # Add a dummy Resource to verify that the app is properly set.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,11 +4,7 @@ from __future__ import unicode_literals
 import copy
 import pytest
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 
 from flask_restx import fields, Model, OrderedModel, SchemaModel
 


### PR DESCRIPTION
in `flask_restx/model.py` and `flask_restx/swagger.py` logic is installed to
circumvent differences in Python2 and Python3 when importing from the
collections module. Some classes from collections has been moved to
`collections.abc` in Python3. `OrderedDict` is not one of them, hence an
ImportError is raised when trying to import `OrderedDict` from
collections.abc. This then leads to importing both `OrderedDict` AND
`MutableMapping`/`Hashable` from `collections.abc` which then raises a
`DeprecationWarning` since `MutableMapping`/`Hashable` lives in
`collections.abc` in Python3.

This patch should fix those `DeprecationWarning`s to be raised.


Output from running `pytest` in a project that uses flask_restx. Here the `DeprecationWarning`s are seen clearly. I've only fixed the ones pertaining to the Python standard library :
```
/Users/kevers/miniconda3/envs/webproj/lib/python3.7/site-packages/flask_restx/model.py:12
  /Users/kevers/miniconda3/envs/webproj/lib/python3.7/site-packages/flask_restx/model.py:12: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import OrderedDict, MutableMapping

/Users/kevers/miniconda3/envs/webproj/lib/python3.7/site-packages/flask_restx/api.py:28
  /Users/kevers/miniconda3/envs/webproj/lib/python3.7/site-packages/flask_restx/api.py:28: DeprecationWarning: The import 'werkzeug.cached_property' is deprecated and will be removed in Werkzeug 1.0. Use 'from werkzeug.utils import cached_property' instead.
    from werkzeug import cached_property

/Users/kevers/miniconda3/envs/webproj/lib/python3.7/site-packages/flask_restx/swagger.py:12
  /Users/kevers/miniconda3/envs/webproj/lib/python3.7/site-packages/flask_restx/swagger.py:12: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from   1 # -*- coding: utf-8 -*-$
'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import OrderedDict, Hashable

  1 # -*- coding: utf-8 -*-$
-- Docs: https://docs.pytest.org/en/latest/warnings.html
```