### PR TITLE
Fix Issue #75: Catch TypeError in marshalling

### DIFF
--- a/flask_restx/fields.py
+++ b/flask_restx/fields.py
@@ -459,7 +459,7 @@ class Integer(NumberMixin, Raw):
             if value is None:
                 return self.default
             return int(value)
-        except ValueError as ve:
+        except (ValueError, TypeError) as ve:
             raise MarshallingError(ve)
 
 
@@ -473,7 +473,7 @@ class Float(NumberMixin, Raw):
     def format(self, value):
         try:
             return float(value)
-        except ValueError as ve:
+        except (ValueError, TypeError) as ve:
             raise MarshallingError(ve)
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -276,9 +276,13 @@ class IntegerFieldTest(BaseFieldTestMixin, NumberTestMixin, FieldTestCase):
     def test_value(self, value, expected):
         self.assert_field(fields.Integer(), value, expected)
 
-    def test_decode_error(self):
+    def test_decode_error_on_invalid_value(self):
         field = fields.Integer()
         self.assert_field_raises(field, "an int")
+
+    def test_decode_error_on_invalid_type(self):
+        field = fields.Integer()
+        self.assert_field_raises(field, {"a": "dict"})
 
 
 class BooleanFieldTest(BaseFieldTestMixin, FieldTestCase):
@@ -330,9 +334,13 @@ class FloatFieldTest(BaseFieldTestMixin, NumberTestMixin, FieldTestCase):
     def test_raises(self):
         self.assert_field_raises(fields.Float(), "bar")
 
-    def test_decode_error(self):
+    def test_decode_error_on_invalid_value(self):
         field = fields.Float()
         self.assert_field_raises(field, "not a float")
+
+    def test_decode_error_on_invalid_type(self):
+        field = fields.Float()
+        self.assert_field_raises(field, {"a": "dict"})
 
 
 PI_STR = (


### PR DESCRIPTION
When marshalling receiving a `MarshallingError` is much more useful than
receiving the underlying exception directly as the `MarshallingError`
has context about where it happened and it means all marshalling issues
can be handled in one place.

This change also catches `TypeError`s from the int and float formatters
so that they are correctly turned into `MarshallingError`s.

See: #75 