### PR TITLE
Remove pytest-sugar from requirements and update pytest

### DIFF
--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -2,13 +2,12 @@ blinker
 Faker==2.0.0
 mock==3.0.5
 pytest==4.6.5; python_version < '3.5'
-pytest==5.0.1; python_version >= '3.5'
+pytest==5.4.1; python_version >= '3.5'
 pytest-benchmark==3.2.2
 pytest-cov==2.7.1
 pytest-flask==0.15.1
 pytest-mock==1.10.4
 pytest-profiling==1.7.0
-pytest-sugar==0.9.2
 tzlocal
 invoke==1.3.0
 readme-renderer==24.0


### PR DESCRIPTION
The pytest-sugar and pytest-5.0.1 are broken for python 3.8. 
Removing pytest-sugar and updating pytest solves the problem and unblocks the CI.