### PR TITLE
fix: Incorrect location type in swagger when multi locations used

### DIFF
--- a/flask_restx/reqparse.py
+++ b/flask_restx/reqparse.py
@@ -287,7 +287,12 @@ class Argument(object):
     def __schema__(self):
         if self.location == "cookie":
             return
-        param = {"name": self.name, "in": LOCATIONS.get(self.location, "query")}
+        param = {'name': self.name}
+        if isinstance(self.location, six.string_types):
+            location = self.location
+        else:
+            location = self.location[-1]
+        param['in'] = LOCATIONS.get(location, 'query')
         _handle_arg_type(self, param)
         if self.required:
             param["required"] = True


### PR DESCRIPTION
A quick fix for an annoying bug where multiple locations cause the swagger documentation to just show "query" instead of either of the locations specified.

Fixes #82 