### PR TITLE
Make it possible to include "unused" models in the generated swagger documentation, refs #90

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -248,6 +248,7 @@ class Api(object):
         )
         app.config.setdefault("RESTX_MASK_HEADER", "X-Fields")
         app.config.setdefault("RESTX_MASK_SWAGGER", True)
+        app.config.setdefault("RESTX_INCLUDE_ALL_MODELS", False)
 
     def __getattr__(self, name):
         try:

--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -241,6 +241,11 @@ class Swagger(object):
                     )
                     paths[path] = serialized
 
+        # register all models if required
+        if current_app.config["RESTX_INCLUDE_ALL_MODELS"]:
+            for m in self.api.models:
+                self.register_model(m)
+
         # merge in the top-level authorizations
         for ns in self.api.namespaces:
             if ns.authorizations:


### PR DESCRIPTION
Changes:

- Added a `RESTX_INCLUDE_ALL_MODELS` config option with a `False` default value.
- `Swagger.as_dict()` now adds all existing models to the documentation if `RESTX_INCLUDE_ALL_MODELS` is set.
- Added tests for `RESTX_INCLUDE_ALL_MODELS`.