### PR TITLE
ProxyFix import issue has been fixed.

### DIFF
--- a/examples/complex.py
+++ b/examples/complex.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from zoo import api
 

--- a/examples/todo.py
+++ b/examples/todo.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from flask_restx import Api, Resource, fields
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app)

--- a/examples/todomvc.py
+++ b/examples/todomvc.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from flask_restx import Api, Resource, fields
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app)


### PR DESCRIPTION
Below error is occurring while running the sample TODO App. 
```
Traceback (most recent call last):
  File "app.py", line 3, in <module>
    from werkzeug.contrib.fixers import ProxyFix
ModuleNotFoundError: No module named 'werkzeug.contrib'

```

Root cause for this issue is `ProxyFix` has been moved from werkzeug.contrib.fixers  to `werkzeug.middleware.proxy_fix.ProxyFix` 

More details can be found at https://werkzeug.palletsprojects.com/en/1.0.x/middleware/proxy_fix/?highlight=proxyfix#werkzeug.middleware.proxy_fix.ProxyFix