### PR TITLE
[docs] Fix incorrect input/output model examples.

### DIFF
--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -536,14 +536,13 @@ For ``POST`` and ``PUT`` methods, use the ``body`` keyword argument to specify t
 
 .. code-block:: python
 
-    fields = api.model('MyModel', {
+    my_model = api.model('MyModel', {
         'name': fields.String(description='The name', required=True),
         'type': fields.String(description='The object type', enum=['A', 'B']),
         'age': fields.Integer(min=0),
     })
 
 
-    @api.model(fields={'name': fields.String, 'age': fields.Integer})
     class Person(fields.Raw):
         def format(self, value):
             return {'name': value.name, 'age': value.age}
@@ -552,11 +551,11 @@ For ``POST`` and ``PUT`` methods, use the ``body`` keyword argument to specify t
     @api.route('/my-resource/<id>', endpoint='my-resource')
     @api.doc(params={'id': 'An ID'})
     class MyResource(Resource):
-        @api.doc(model=fields)
+        @api.doc(model=my_model)
         def get(self, id):
             return {}
 
-        @api.doc(model='MyModel', body=Person)
+        @api.doc(model=my_model, body=Person)
         def post(self, id):
             return {}
 


### PR DESCRIPTION
This example has 2 main issues:

1. The model assigned to the fields variable shadows the flask_restx.fields
   module, causing an AttributeError
2. The @api.model usage is simply incorrect, it is not intended to be
   used as a class decorator on custom field implementations.

The corrections made here show what I *assume* the original author intended to show.

https://github.com/python-restx/flask-restx/issues/117#issuecomment-625756628