### PR TITLE
Added ability to customize/override 'consumes'

### DIFF
--- a/flask_restx/namespace.py
+++ b/flask_restx/namespace.py
@@ -325,6 +325,10 @@ class Namespace(object):
         header.update(kwargs)
         return self.doc(headers={name: header})
 
+    def consumes(self, mimetypes):
+        """A decorator to specify the MIME types the API can consume"""
+        return self.doc(consumes=mimetypes)
+
     def produces(self, mimetypes):
         """A decorator to specify the MIME types the API can produce"""
         return self.doc(produces=mimetypes)

--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -465,7 +465,9 @@ class Swagger(object):
         # Handle form exceptions:
         doc_params = list(doc.get("params", {}).values())
         all_params = doc_params + (operation["parameters"] or [])
-        if all_params and any(p["in"] == "formData" for p in all_params):
+        if "consumes" in doc[method]:
+            operation["consumes"] = doc[method]["consumes"]
+        elif all_params and any(p["in"] == "formData" for p in all_params):
             if any(p["type"] == "file" for p in all_params):
                 operation["consumes"] = ["multipart/form-data"]
             else:

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -2910,6 +2910,36 @@ class SwaggerTest(object):
         assert "produces" in post_operation
         assert post_operation["produces"] == ["application/octet-stream"]
 
+    def test_consumes_method(self, api, client):
+        @api.route("/test/", endpoint="test")
+        class TestResource(restx.Resource):
+            def get(self):
+                pass
+
+            @api.consumes(["text/plain; encoding=utf-8"])
+            def put(self):
+                pass
+
+            @api.doc(consumes=["text/plain"])
+            def post(self):
+                pass
+
+        data = client.get_specs()
+
+        assert "consumes" in data
+        assert data["consumes"] == ["application/json"]
+
+        get_operation = data["paths"]["/test/"]["get"]
+        assert "consumes" not in get_operation
+
+        put_operation = data["paths"]["/test/"]["put"]
+        assert "consumes" in put_operation
+        assert put_operation["consumes"] == ["text/plain; encoding=utf-8"]
+
+        post_operation = data["paths"]["/test/"]["post"]
+        assert "consumes" in post_operation
+        assert post_operation["consumes"] == ["text/plain"]
+
     def test_deprecated_resource(self, api, client):
         @api.deprecated
         @api.route("/test/", endpoint="test")


### PR DESCRIPTION
I have needed the ability to override the Swagger spec to support "consumes" values other than `application/json`. I added this ability and a test to confirm that it works. It can be used like `@app.consumes()` or `@app.doc(consumes=[])` just like how "produces" works.