### PR TITLE
Update the Flask documentation URL in the File Upload section

### DIFF
--- a/doc/parsing.rst
+++ b/doc/parsing.rst
@@ -249,7 +249,7 @@ and to set the type to :class:`~werkzeug.datastructures.FileStorage`.
             url = do_something_with_file(uploaded_file)
             return {'url': url}, 201
 
-See the `dedicated Flask documentation section <http://flask.pocoo.org/docs/0.10/patterns/fileuploads/>`_.
+See the `dedicated Flask documentation section <https://flask.palletsprojects.com/en/1.1.x/patterns/fileuploads/>`_.
 
 
 Error Handling


### PR DESCRIPTION
In the File Upload section of the documentation, the link to the Flask documentation section was broken/outdated. Changed it from https://flask.palletsprojects.com/en/0.10.x/patterns/fileuploads/ to https://flask.palletsprojects.com/en/1.1.x/patterns/fileuploads/