### PR TITLE
Update example.rst

### DIFF
--- a/doc/example.rst
+++ b/doc/example.rst
@@ -7,7 +7,7 @@ Here is a full example of a `TodoMVC <http://todomvc.com/>`_ API.
 
     from flask import Flask
     from flask_restx import Api, Resource, fields
-    from werkzeug.contrib.fixers import ProxyFix
+    from werkzeug.middleware.proxy_fix import ProxyFix
 
     app = Flask(__name__)
     app.wsgi_app = ProxyFix(app.wsgi_app)


### PR DESCRIPTION
Hi Maintainers!

After copying the example from the read the docs page I got the below error:

```
Error: While importing "app", an ImportError was raised:

Traceback (most recent call last):
  File "C:\Users\44780\PycharmProjects\muck-around-flask-restx\venv\lib\site-packages\flask\cli.py", line 240, in locate_app
    __import__(module_name)
  File "C:\Users\44780\PycharmProjects\muck-around-flask-restx\app.py", line 4, in <module>
    from werkzeug.contrib.fixers import ProxyFix
ModuleNotFoundError: No module named 'werkzeug.contrib'
```

Looks like this has been solved in commit `e186dc48cc4680aa3a7ce4b3d6ad2f6f44992816` for the examples folder but not done in this example. 

This is my first pull request so feedback welcome. 

All the best
Rich