### PR TITLE
Add support for recursive models

### DIFF
--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -657,6 +657,8 @@ class Swagger(object):
         if name not in self.api.models:
             raise ValueError("Model {0} not registered".format(name))
         specs = self.api.models[name]
+        if name in self._registered_models:
+            return ref(model)
         self._registered_models[name] = specs
         if isinstance(specs, ModelBase):
             for parent in specs.__parents__:

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -2057,6 +2057,27 @@ class SwaggerTest(object):
 
         client.get_specs(status=500)
 
+    def test_recursive_model(self, api, client):
+        fields = api.model('Person', {
+            'name': restx.fields.String,
+            'age': restx.fields.Integer,
+            'birthdate': restx.fields.DateTime,
+        })
+
+        fields["children"] = restx.fields.List(
+            restx.fields.Nested(fields),
+            default=[],
+        )
+
+        @api.route('/recursive-model/')
+        @api.doc(get={'model': fields})
+        class ModelAsDict(restx.Resource):
+            @api.marshal_with(fields)
+            def get(self):
+                return {}
+
+        client.get_specs(status=200)
+
     def test_specs_no_duplicate_response_keys(self, api, client):
         """
         This tests that the swagger.json document will not be written with duplicate object keys


### PR DESCRIPTION
This is a port of https://github.com/noirbizarre/flask-restplus/pull/656
It should resolve #110 

Thanks to @buggyspace, @drarok and @edwardfung123 for identifying and fixing this.

I've followed the CONTRIBUTING.rst file, but couldn't locate the changelog to add this change, is this out of date?