### PR TITLE
Add custom swagger json url support

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -116,6 +116,7 @@ class Api(object):
         validate=None,
         tags=None,
         prefix="",
+        swagger_json_url="",
         ordered=False,
         default_mediatype="application/json",
         decorators=None,
@@ -158,6 +159,7 @@ class Api(object):
         self.representations = OrderedDict(DEFAULT_REPRESENTATIONS)
         self.urls = {}
         self.prefix = prefix
+        self.swagger_json_url=swagger_json_url
         self.default_mediatype = default_mediatype
         self.decorators = decorators if decorators else []
         self.catch_all_404s = catch_all_404s
@@ -507,6 +509,8 @@ class Api(object):
 
         :rtype: str
         """
+        if self.swagger_json_url != "":
+            return self.swagger_json_url
         return url_for(self.endpoint("specs"), _external=True)
 
     @property


### PR DESCRIPTION
My flask application was behind a reverse proxy, for the application everything was running at 127.0.0.1, but the server's external address was not 127.0.0.1, so when displaying the doc it was loading the json from 127.0.0.1 instead of the external url of my server, so I added a small option to manually change the address of the json for swagger