### PR TITLE
Fix Issue #184: don't treat empty dict as None when skip_none=True

### DIFF
--- a/flask_restx/marshalling.py
+++ b/flask_restx/marshalling.py
@@ -80,7 +80,7 @@ def marshal(data, fields, envelope=None, skip_none=False, mask=None, ordered=Fal
                 if is_wildcard:
 
                     def _append(k, v):
-                        if skip_none and (v is None or v == OrderedDict() or v == {}):
+                        if skip_none and (v is None or v == OrderedDict()):
                             return
                         items.append((k, v))
 
@@ -97,7 +97,7 @@ def marshal(data, fields, envelope=None, skip_none=False, mask=None, ordered=Fal
                     continue
 
             keys.append(key)
-            if skip_none and (value is None or value == OrderedDict() or value == {}):
+            if skip_none and (value is None or (isinstance(value, OrderedDict) and value == OrderedDict())):
                 continue
             items.append((key, value))
 
@@ -183,7 +183,7 @@ def _marshal(data, fields, envelope=None, skip_none=False, mask=None, ordered=Fa
 
     if skip_none:
         items = (
-            (k, v) for k, v in items if v is not None and v != OrderedDict() and v != {}
+            (k, v) for k, v in items if v is not None and (not isinstance(v, OrderedDict) or v != OrderedDict())
         )
 
     out = OrderedDict(items) if ordered else dict(items)

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -83,9 +83,9 @@ class MarshallingTest(object):
         model = OrderedDict(
             [("foo", fields.Raw), ("bat", fields.Raw), ("qux", fields.Raw)]
         )
-        marshal_dict = OrderedDict([("foo", "bar"), ("bat", None)])
+        marshal_dict = OrderedDict([("foo", "bar"), ("bat", None), ("qux", {})])
         output = marshal(marshal_dict, model, skip_none=True)
-        assert output == {"foo": "bar"}
+        assert output == {"foo": "bar", "qux": {}}
 
     def test_marshal_wildcard_with_skip_none(self):
         wild = fields.Wildcard(fields.String)
@@ -286,14 +286,27 @@ class MarshallingTest(object):
                 (
                     "fee",
                     fields.Nested(
-                        OrderedDict([("fye", fields.String)]), skip_none=True
+                        OrderedDict([("fye", fields.String)]), skip_none=True, allow_null=True
+                    ),
+                ),
+                (
+                    "bee",
+                    fields.Nested(
+                        OrderedDict([("bye", fields.String)]), skip_none=True
                     ),
                 ),
             ]
         )
-        marshal_fields = OrderedDict([("foo", "bar"), ("bat", "baz"), ("fee", None)])
+        marshal_fields = OrderedDict(
+            [
+                ("foo", "bar"),
+                ("bat", "baz"),
+                ("fee", None),
+                ("bee", {}),
+            ]
+        )
         output = marshal(marshal_fields, model, skip_none=True)
-        expected = OrderedDict([("foo", "bar")])
+        expected = OrderedDict([("foo", "bar"), ("bee", {})])
         assert output == expected
 
     def test_allow_null_presents_data(self):


### PR DESCRIPTION
This PR suggests a fix for issue #184:

* Remove the checks against values that omit an attribute if it's an empty dictionary
* Add a stricter check for `OrderedDict`
* Tests