### PR TITLE
Add default swagger filename to Api.

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -106,6 +106,7 @@ class Api(object):
     :param url_scheme: If set to a string (e.g. http, https), then the specs_url and base_url will explicitly use this
         scheme regardless of how the application is deployed. This is necessary for some deployments behind a reverse
         proxy.
+    :param str default_swagger_filename: The default swagger filename.
     """
 
     def __init__(
@@ -136,6 +137,7 @@ class Api(object):
         serve_challenge_on_401=False,
         format_checker=None,
         url_scheme=None,
+        default_swagger_filename="swagger.json",
         **kwargs
     ):
         self.version = version
@@ -166,6 +168,7 @@ class Api(object):
         self._refresolver = None
         self.format_checker = format_checker
         self.namespaces = []
+        self.default_swagger_filename = default_swagger_filename
 
         self.ns_paths = dict()
 
@@ -308,7 +311,7 @@ class Api(object):
                 app_or_blueprint,
                 SwaggerView,
                 self.default_namespace,
-                "/swagger.json",
+                "/" + self.default_swagger_filename,
                 endpoint=endpoint,
                 resource_class_args=(self,),
             )

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -3323,3 +3323,25 @@ class SwaggerDeprecatedTest(object):
 
         path = data["paths"]["/with-parser/"]
         assert "parameters" not in path
+
+    def test_nondefault_swagger_filename(self, app, client):
+        api = restx.Api(doc="/doc/test", default_swagger_filename="test.json")
+        ns = restx.Namespace("ns1")
+
+        @ns.route("/test1")
+        class Ns(restx.Resource):
+            @ns.doc("Docs")
+            def get(self):
+                pass
+
+        api.add_namespace(ns)
+        api.init_app(app)
+
+        resp = client.get("/test.json")
+        assert resp.status_code == 200
+        assert resp.content_type == "application/json"
+        resp = client.get("/doc/test")
+        assert resp.status_code == 200
+        assert resp.content_type == "text/html; charset=utf-8"
+        resp = client.get("/ns1/test1")
+        assert resp.status_code == 200


### PR DESCRIPTION
This PR suggests a fix for issue #191:

*  Add default_swagger_filename parameter to restx's api.py instead of hardcoding it.