### PR TITLE
Adds config.SWAGGER_PREAUTHORIZEAPIKEY key

### DIFF
--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -1031,6 +1031,31 @@ you can register a custom view function with the :meth:`~Api.documentation` deco
     def custom_ui():
         return apidoc.ui_for(api)
 
+Preauthorization for ApiKey
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can specify a way to fetch a preauthorized ``apiKey`` by setting the
+``config.SWAGGER_PREAUTHORIZEAPIKEY`` with a function returning ``False`` or
+preauthorization informations.
+
+.. code-block:: python
+
+    authorizations = {
+        'apikey': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'X-API'
+        }
+    }
+    api = Api(app, security=['apikey'], authorizations=authorizations)
+
+    def pre_auth():
+        if 'apikey' in session:
+            return ('X-API', session['apikey'])
+        return False
+
+    app.config.SWAGGER_PREAUTHORIZEAPIKEY = pre_auth
+
 Configuring "Try it Out"
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/flask_restx/templates/swagger-ui.html
+++ b/flask_restx/templates/swagger-ui.html
@@ -68,7 +68,12 @@
                 {%- endif %}
                 displayOperationId: {{ config.SWAGGER_UI_OPERATION_ID|default(False)|tojson }},
                 displayRequestDuration: {{ config.SWAGGER_UI_REQUEST_DURATION|default(False)|tojson }},
-                docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"
+                docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}",
+                {{% if config.SWAGGER_PREAUTHORIZEAPIKEY is defined and config.SWAGGER_PREAUTHORIZEAPIKEY() -%}}
+                  onComplete: function() {
+                    ui.preauthorizeApiKey("{{config.SWAGGER_PREAUTHORIZEAPIKEY()[0]|safe}}", "{{config.SWAGGER_PREAUTHORIZEAPIKEY()[1]|safe}}");
+                  }
+                {{%- endif %}}
             })
 
             {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}


### PR DESCRIPTION
Solution proposal for #196

This configuration key is designed to contain a function returning
- False if no preauthorization needed/wanted
- A tuple(authorization_name, key) if preauthorization wanted

The documentation is updated too.