### PR TITLE
Implements Swagger apiKey Preauthorization

### DIFF
--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -1053,6 +1053,35 @@ supporting the same values as the ``supportedSubmitMethods`` `Swagger UI paramet
 
     api = Api(app)
 
+Preauthorizing apiKey
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``flask_restx.Api`` class has a ``apikey_preauthorization`` decorator
+allowing to register a function returning wether or not preauthorization
+should be enabled.
+
+Expected returned values for this function are ``False`` or a tuple
+``(Authorization_name, Auth_key)``
+
+
+.. code-block:: python
+
+    authorizations = {
+        'apikey': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'X-API'
+        }
+    }
+    api = Api(app, security=['X-API'],authorizations=authorizations)
+
+    @api.apikey_preauthorization
+    def check_preauth():
+        if 'APIKEY' in session:
+            return ('X-API', session['APIKEY'])
+        return False
+
+
 Disabling the documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -158,6 +158,7 @@ class Api(object):
         self.representations = OrderedDict(DEFAULT_REPRESENTATIONS)
         self.urls = {}
         self.prefix = prefix
+        self._preauthorize_apikey = None
         self.default_mediatype = default_mediatype
         self.decorators = decorators if decorators else []
         self.catch_all_404s = catch_all_404s
@@ -409,6 +410,16 @@ class Api(object):
             return resp
         else:
             raise InternalServerError()
+
+    def apikey_preauthorization(self, func):
+        """
+        A decorator to specify a function returning preauthorization info
+
+        The decorated function should returns False if not preauthorization
+        wanted, else returns a tuple(Authorization_Name, KEY)
+        """
+        self._preauthorize_apikey = func
+        return func
 
     def documentation(self, func):
         """A decorator to specify a view function for the documentation"""

--- a/flask_restx/apidoc.py
+++ b/flask_restx/apidoc.py
@@ -35,4 +35,6 @@ def swagger_static(filename):
 
 def ui_for(api):
     """Render a SwaggerUI for a given API"""
-    return render_template("swagger-ui.html", title=api.title, specs_url=api.specs_url)
+    return render_template("swagger-ui.html", title=api.title,
+                           specs_url=api.specs_url,
+                           preauthorize_apikey=api._preauthorize_apikey)

--- a/flask_restx/templates/swagger-ui.html
+++ b/flask_restx/templates/swagger-ui.html
@@ -68,7 +68,12 @@
                 {%- endif %}
                 displayOperationId: {{ config.SWAGGER_UI_OPERATION_ID|default(False)|tojson }},
                 displayRequestDuration: {{ config.SWAGGER_UI_REQUEST_DURATION|default(False)|tojson }},
-                docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"
+                docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}",
+                {% if preauthorize_apikey and preauthorize_apikey() -%}
+                onComplete: function() {
+                    ui.preauthorizeApiKey("{{preauthorize_apikey()[0]|safe}}", "{{preauthorize_apikey()[1]|safe}}");
+                }
+                {%- endif %}
             })
 
             {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}


### PR DESCRIPTION
Solution proposal for #196

The flask_restx.Api class provides an apikey_preauthorization decorator
allowing to register a function returning wether or not preauthorization is
wanted.

In the case where preauthorization is wanted, the registered function should
returns a tuple with Authorization_name and the APIKey.