### PR TITLE
Allow example=False

### DIFF
--- a/flask_restx/fields.py
+++ b/flask_restx/fields.py
@@ -156,7 +156,7 @@ class Raw(object):
         self.description = description
         self.required = required
         self.readonly = readonly
-        self.example = example or self.__schema_example__
+        self.example = example if example is not None else self.__schema_example__
         self.mask = mask
 
     def format(self, value):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -298,6 +298,14 @@ class BooleanFieldTest(BaseFieldTestMixin, FieldTestCase):
         assert not field.required
         assert field.__schema__ == {"type": "boolean", "default": True}
 
+    def test_with_example(self):
+        field = fields.Boolean(default=True, example=False)
+        assert field.__schema__ == {
+            "type": "boolean",
+            "default": True,
+            "example": False,
+        }
+
     @pytest.mark.parametrize(
         "value,expected",
         [


### PR DESCRIPTION
Currently with a Boolean field it isn't possible to set the example to
'False' since it would instead be set to None.

Fixes #206