### PR TITLE
Use relative path for `api.specs_url`.

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -503,11 +503,11 @@ class Api(object):
     @property
     def specs_url(self):
         """
-        The Swagger specifications absolute url (ie. `swagger.json`)
+        The Swagger specifications relative url (ie. `swagger.json`)
 
         :rtype: str
         """
-        return url_for(self.endpoint("specs"), _external=True)
+        return url_for(self.endpoint("specs"))
 
     @property
     def base_url(self):


### PR DESCRIPTION
This resolves any issues with mixed content when running behind an HTTPS reverse proxy.
There is no valid use case for using absolute over relative here, and only causes additional issues.

Resolves #188