### PR TITLE
Allow to setup schema format of the field

### DIFF
--- a/flask_restx/fields.py
+++ b/flask_restx/fields.py
@@ -129,6 +129,7 @@ class Raw(object):
     :param bool readonly: Is the field read only ? (for documentation purpose)
     :param example: An optional data example (for documentation purpose)
     :param callable mask: An optional mask function to be applied to output
+    :param schema_format: An optional JSON/Swagger schema format
     """
 
     #: The JSON/Swagger schema type
@@ -148,6 +149,7 @@ class Raw(object):
         readonly=None,
         example=None,
         mask=None,
+        schema_format=None,
         **kwargs
     ):
         self.attribute = attribute
@@ -158,6 +160,8 @@ class Raw(object):
         self.readonly = readonly
         self.example = example if example is not None else self.__schema_example__
         self.mask = mask
+        if schema_format is not None:
+            self.__schema_format__ = schema_format
 
     def format(self, value):
         """

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -180,6 +180,10 @@ class RawFieldTest(BaseFieldTestMixin, FieldTestCase):
         field = fields.Raw()
         assert field.output("bar.value", foo) == 42
 
+    def test_format(self):
+        field = fields.Raw(schema_format="something")
+        assert field.__schema_format__ == "something"
+
 
 class StringFieldTest(StringTestMixin, BaseFieldTestMixin, FieldTestCase):
     field_class = fields.String


### PR DESCRIPTION
Raw object has __schema_format__ class-level property that is used while
constucting jsonschema.
Making it configurable while describing an obj allows to avoid
constructing empty python classes that overrides just one property.