### PR TITLE
Misleading {error_msg} information in the documentation

### DIFF
--- a/doc/parsing.rst
+++ b/doc/parsing.rst
@@ -315,11 +315,7 @@ to ``Argument`` (and also ``RequestParser.add_argument``).
 
 If no help parameter is provided, the error message for the field will be
 the string representation of the type error itself. If ``help`` is provided,
-then the error message will be the value of ``help``.
-
-``help`` may include an interpolation token, ``{error_msg}``, that will be
-replaced with the string representation of the type error. This allows the
-message to be customized while preserving the original error::
+then the error message will be the value of ``help`` plus the string representation of the type error.
 
     from flask_restx import reqparse
 
@@ -328,7 +324,7 @@ message to be customized while preserving the original error::
     parser.add_argument(
         'foo',
         choices=('one', 'two'),
-        help='Bad choice: {error_msg}'
+        help='Bad choice:'
     )
 
     # If a request comes in with a value of "three" for `foo`:

--- a/flask_restx/reqparse.py
+++ b/flask_restx/reqparse.py
@@ -87,9 +87,7 @@ class Argument(object):
         iterator. The last item listed takes precedence in the result set.
     :param choices: A container of the allowable values for the argument.
     :param help: A brief description of the argument, returned in the
-        response when the argument is invalid. May optionally contain
-        an "{error_msg}" interpolation token, which will be replaced with
-        the text of the error raised by the type converter.
+        response when the argument is invalid.
     :param bool case_sensitive: Whether argument values in the request are
         case sensitive or not (this will convert all values to lowercase)
     :param bool store_missing: Whether the arguments default value should


### PR DESCRIPTION
I know that reqparse is deprecated yet, the documentation for the request parsing contains the text

```
help may include an interpolation token, {error_msg}, that will be replaced with the string representation of the type error. This allows the message to be customized while preserving the original error:
```
but when I try this basically `{error_msg}` is not replaced and when I checked the [reqparse](https://github.com/python-restx/flask-restx/blob/84ae8361526005b8f1cf147b428d00c1faa86491/flask_restx/reqparse.py#L196)

```
 error_msg = (
            " ".join([six.text_type(self.help), error_str]) if self.help else error_str
        )
```
 
maybe this was the behavior once but changed later. I don't know if you prefer changing the behavior or documentation. I changed the documentation, hope this helps.

