### PR TITLE
Cap aniso8601 for python 2.7 environments

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,4 +1,5 @@
-aniso8601>=0.82
+aniso8601==8.0.0; python_version < '3.5'
+aniso8601>=0.82; python_version >= '3.5'
 jsonschema
 Flask>=0.8
 werkzeug


### PR DESCRIPTION
aniso8601==8.1.0 * raises ValuError in case of non-string arguments
passed to get_date_resolution and parse_date methods.

It is ok for Python3 envs, but backward incompatible for Python 2.7
where we are passing unicode (at least in unittests).

* https://bitbucket.org/nielsenb/aniso8601/src/master/CHANGELOG.rst