### PR TITLE
Fixing unregistered nested ordered model bug

### DIFF
--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -18,7 +18,7 @@ from flask import current_app
 from werkzeug.routing import parse_rule
 
 from . import fields
-from .model import Model, ModelBase
+from .model import Model, ModelBase, OrderedModel
 from .reqparse import RequestParser
 from .utils import merge, not_none, not_none_sorted
 from ._http import HTTPStatus
@@ -663,7 +663,7 @@ class Swagger(object):
         if isinstance(specs, ModelBase):
             for parent in specs.__parents__:
                 self.register_model(parent)
-        if isinstance(specs, Model):
+        if isinstance(specs, (Model, OrderedModel)):
             for field in itervalues(specs):
                 self.register_field(field)
         return ref(model)


### PR DESCRIPTION
When setting `ordered=True` in a Namespace, nested models are not registered with `Swagger` giving a "Could not resolve reference" in Swagger documentation. This pull request fixes this.

Related bug reports and pull requests:

- https://stackoverflow.com/questions/56079764/flask-restplus-nested-fields-not-getting-registered-into-swaggerui
- https://github.com/noirbizarre/flask-restplus/issues/643
- https://github.com/noirbizarre/flask-restplus/pull/616/commits/847664e1b144a3da82e243b8fdf11b7677382e71
- https://github.com/python-restx/flask-restx/issues/128