### PR TITLE
Update api doc

### DIFF
--- a/flask_restx/apidoc.py
+++ b/flask_restx/apidoc.py
@@ -24,7 +24,7 @@ apidoc = Apidoc(
     __name__,
     template_folder="templates",
     static_folder="static",
-    static_url_path="/swaggerui",
+    static_url_path="/",
 )
 
 


### PR DESCRIPTION
Current static_url_path does not works with oauth2.0 accessCode since the oauth-redirect.html exposed like this /swaggerui/oauth-redirect.html. After removing the static_url_path, oauth2-redirect.html is accessible and the authentication works.