### PR TITLE
allow definition of own swagger schema for path variables.

### DIFF
--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -88,6 +88,11 @@ def extract_path_params(path):
             param["type"] = PATH_TYPES[converter]
         elif converter in current_app.url_map.converters:
             param["type"] = "string"
+
+            converterObj = current_app.url_map.converters[converter]
+            hasSchema = hasattr(converterObj, '__restx_schema__')
+            if hasSchema and isinstance(converterObj.__restx_schema__, dict):
+                param.update(converterObj.__restx_schema__)
         else:
             raise ValueError("Unsupported type converter: %s" % converter)
         params[variable] = param


### PR DESCRIPTION
Using custom converters to store the '\_\_restx_schema\_\_' dict.
The dict updates the parameter for swagger.

Tested with (and without):
```
class DatabaseConverter(BaseConverter):
    __restx_schema__ = {'type': 'string', 'enum': ['ProdDB','TestDB1','TestDB2']}
```
The result, was a dropdown menu instead of an input field.