### PR TITLE
Fix namespace error handlers when propagate_exceptions=True

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -666,7 +666,7 @@ class Api(object):
         if (
             not isinstance(e, HTTPException)
             and current_app.propagate_exceptions
-            and not isinstance(e, tuple(self.error_handlers.keys()))
+            and not isinstance(e, tuple(self._own_and_child_error_handlers.keys()))
         ):
 
             exc_type, exc_value, tb = sys.exc_info()


### PR DESCRIPTION
Fixes issue https://github.com/python-restx/flask-restx/issues/285.

When an `errorhandler` is registered on a namespace, and `PROPAGATE_EXCEPTIONS` is set to `True` in the Flask app, then the namespace handler will not catch the exceptions. It looks like this is due to the `handle_error` function not checking the error handlers that exist in any child classes.