### PR TITLE
add example bash doc and force json on payload, issue #248

### DIFF
--- a/doc/example.rst
+++ b/doc/example.rst
@@ -102,7 +102,16 @@ Here is a full example of a `TodoMVC <http://todomvc.com/>`_ API.
         app.run(debug=True)
 
 
+Running the example, you can access the api through a cli. 
+Following is an example how one can use it to add a new task to the todo-list.
+
+.. code-block:: bash
+
+  curl http://localhost:5000/todos/ -H "Content-Type: application/json" -d '{"task": "Remember the milk"}' -X POST
+
 
 You can find other examples in the `github repository examples folder`_.
-
+  
 .. _github repository examples folder: https://github.com/python-restx/flask-restx/tree/master/examples
+
+

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -783,7 +783,7 @@ class Api(object):
     @property
     def payload(self):
         """Store the input payload in the current request context"""
-        return request.get_json()
+        return request.get_json(force=True)
 
     @property
     def refresolver(self):


### PR DESCRIPTION
Add an example of usage from curl-cli for the full example at https://flask-restx.readthedocs.io/en/latest/example.html and force json usage in payload, according to suggestions in https://github.com/python-restx/flask-restx/issues/248. 