### PR TITLE
Stops calling got_request_exception for exceptions explicitly handled.

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -659,8 +659,6 @@ class Api(object):
         :param Exception e: the raised Exception object
 
         """
-        got_request_exception.send(current_app._get_current_object(), exception=e)
-
         # When propagate_exceptions is set, do not return the exception to the
         # client if a handler is configured for the exception.
         if (
@@ -690,6 +688,10 @@ class Api(object):
                 )
                 break
         else:
+            # Flask docs say: "This signal is not sent for HTTPException or other exceptions that have error handlers
+            # registered, unless the exception was raised from an error handler."
+            got_request_exception.send(current_app._get_current_object(), exception=e)
+
             if isinstance(e, HTTPException):
                 code = HTTPStatus(e.code)
                 if include_message_in_response:


### PR DESCRIPTION
See https://github.com/pallets/flask/pull/3883/files regarding how 'got_request_exception' works. https://github.com/getsentry/sentry-python creates a Sentry issue each time  'got_request_exception' is sent, which is not desirable if one has a custom exception handler.

I tested this by using my fork and running my comprehensive test suite, which covers exceptions with and without handlers. I ran with Sentry initialized and it was not signaled with my fork when an exception that was explicitly handled by an errorhandler was raised.