### PR TITLE
The Flask/Blueprint API moved to the Scaffold base class

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -17,7 +17,7 @@ from types import MethodType
 
 from flask import url_for, request, current_app
 from flask import make_response as original_flask_make_response
-from flask.helpers import _endpoint_from_view_func
+from flask.scaffold import _endpoint_from_view_func
 from flask.signals import got_request_exception
 
 from jsonschema import RefResolver

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -17,7 +17,10 @@ from types import MethodType
 
 from flask import url_for, request, current_app
 from flask import make_response as original_flask_make_response
-from flask.scaffold import _endpoint_from_view_func
+try:
+    from flask.helpers import _endpoint_from_view_func
+except ImportError:
+    from flask.scaffold import _endpoint_from_view_func
 from flask.signals import got_request_exception
 
 from jsonschema import RefResolver


### PR DESCRIPTION
Changed in: https://github.com/pallets/flask/commit/b146a13f633b0e2e26e3b8383b3db0feb563bc83

Fixes: #308

Signed-off-by: Jürgen Löhel <juergen.loehel@inlyse.com>