### PR TITLE
No ".dev" should appear in package.json version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flask-restx",
-  "version": "0.4.1.dev",
+  "version": "0.4.1-dev",
   "description": "Fully featured framework for fast, easy and documented API development with Flask",
   "repository": "python-restx/flask-restx",
   "keywords": [


### PR DESCRIPTION
This is the error message I got when I ran `inv assets`:

    npm WARN Invalid version: "0.4.1.dev"
    npm WARN flask-restx No description
    npm WARN flask-restx No repository field.
    npm WARN flask-restx No README data
    npm WARN flask-restx No license field.