### PR TITLE
Issue #240: return default when passed float field is None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ node_modules
 
 # pyenv
 .python-version
+.venv
 
 # Jet Brains
 .idea

--- a/flask_restx/fields.py
+++ b/flask_restx/fields.py
@@ -481,6 +481,8 @@ class Float(NumberMixin, Raw):
 
     def format(self, value):
         try:
+            if value is None:
+                return self.default
             return float(value)
         except (ValueError, TypeError) as ve:
             raise MarshallingError(ve)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -333,6 +333,12 @@ class FloatFieldTest(BaseFieldTestMixin, NumberTestMixin, FieldTestCase):
         assert not field.required
         assert field.__schema__ == {"type": "number", "default": 0.5}
 
+    def test_default_on_none(self):
+        field = fields.Float(default=0.5)
+        assert not field.required
+        assert field.__schema__ == {"type": "number", "default": 0.5}
+        self.assert_field(field, None, 0.5)
+
     @pytest.mark.parametrize(
         "value,expected", [("-3.13", -3.13), (str(-3.13), -3.13), (3, 3.0),]
     )


### PR DESCRIPTION
This resolves issue #240 and provides a test to cover the case. Picks up from where PR #277 stalled. 

.venv is also added to the .gitignore (created by [virtual-fish](https://github.com/justinmayer/virtualfish)--let me know if you'd like it removed!