### PR TITLE
Issue #304: pass along ordered parameter

### DIFF
--- a/flask_restx/fields.py
+++ b/flask_restx/fields.py
@@ -862,7 +862,12 @@ class Wildcard(Raw):
                     # we are using pop() so that we don't
                     # loop over the whole object every time dropping the
                     # complexity to O(n)
-                    (objkey, val) = self._flat.pop()
+                    if ordered:
+                        # Get first element if respecting order
+                        (objkey, val) = self._flat.pop(0)
+                    else:
+                        # Previous default retained
+                        (objkey, val) = self._flat.pop()
                     if (
                         objkey not in self._cache
                         and objkey not in self.exclude

--- a/flask_restx/marshalling.py
+++ b/flask_restx/marshalling.py
@@ -76,7 +76,7 @@ def marshal(data, fields, envelope=None, skip_none=False, mask=None, ordered=Fal
                     if keys:
                         field.exclude |= set(keys)
                         keys = []
-                value = field.output(dkey, data)
+                value = field.output(dkey, data, ordered=ordered)
                 if is_wildcard:
 
                     def _append(k, v):

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -221,6 +221,21 @@ class MarshallingTest(object):
 
         assert output == expected
 
+    def test_marshal_ordered(self):
+        model = OrderedDict(
+            [("foo", fields.Raw), ("baz", fields.Raw), ("bar", fields.Raw)]
+        )
+        marshal_fields = {
+            "foo": 1,
+            "baz": 2,
+            "bar": 3
+        }
+        expected_ordered = OrderedDict([("foo", 1), ("baz", 2), ("bar", 3)])
+        ordered_output = marshal(marshal_fields, model, ordered=True)
+        assert ordered_output == expected_ordered
+        unordered_output = marshal(marshal_fields, model)
+        assert not isinstance(unordered_output, OrderedDict)
+
     def test_marshal_nested_ordered(self):
         model = OrderedDict(
             [("foo", fields.Raw), ("fee", fields.Nested({"fye": fields.String,}))]


### PR DESCRIPTION
This resolves issue #304. The `ordered` parameter was not being passed along to `output()` in one case. It is now passed, and items are popped from the front to retain the original order. Original behavior is kept in case someone needs/wants it.

Test case also added to check ordered vs. not ordered.