### PR TITLE
Issue #240: use default on None Float field

### DIFF
--- a/flask_restx/fields.py
+++ b/flask_restx/fields.py
@@ -481,6 +481,8 @@ class Float(NumberMixin, Raw):
 
     def format(self, value):
         try:
+            if value is None:
+                return self.default
             return float(value)
         except (ValueError, TypeError) as ve:
             raise MarshallingError(ve)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -334,7 +334,7 @@ class FloatFieldTest(BaseFieldTestMixin, NumberTestMixin, FieldTestCase):
         assert field.__schema__ == {"type": "number", "default": 0.5}
 
     def test_none_uses_default(self):
-        field = fields.float(default=0.5)
+        field = fields.Float(default=0.5)
         assert not field.required
         assert field.__schema__ == {"type": "number", "default": 0.5}
         assert field.format(None) == 0.5

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -333,6 +333,12 @@ class FloatFieldTest(BaseFieldTestMixin, NumberTestMixin, FieldTestCase):
         assert not field.required
         assert field.__schema__ == {"type": "number", "default": 0.5}
 
+    def test_none_uses_default(self):
+        field = fields.float(default=0.5)
+        assert not field.required
+        assert field.__schema__ == {"type": "number", "default": 0.5}
+        assert field.format(None) == 0.5
+
     @pytest.mark.parametrize(
         "value,expected", [("-3.13", -3.13), (str(-3.13), -3.13), (3, 3.0),]
     )


### PR DESCRIPTION
This resolves issue #240 and provides a test to cover the case. Picks up from where PR #277 stalled. 

.venv is also added to the .gitignore (created by [virtual-fish](https://github.com/justinmayer/virtualfish)--let me know if you'd like it removed!