### PR TITLE
Update broken/outdated documentation links

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file
 root = true

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -50,7 +50,7 @@ You need to install some dependencies to develop on flask-restx:
 
     $ pip install -e .[dev]
 
-An [Invoke](http://www.pyinvoke.org/) ``tasks.py`` is provided to simplify the common tasks:
+An `Invoke <https://www.pyinvoke.org/>`_ ``tasks.py`` is provided to simplify the common tasks:
 
 .. code-block:: console
 

--- a/README.rst
+++ b/README.rst
@@ -175,8 +175,8 @@ Documentation
 The documentation is hosted `on Read the Docs <http://flask-restx.readthedocs.io/en/latest/>`_
 
 
-.. _Flask: http://flask.pocoo.org/
-.. _Swagger: http://swagger.io/
+.. _Flask: https://flask.palletsprojects.com/
+.. _Swagger: https://swagger.io/
 
 
 Contribution

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -332,7 +332,7 @@ texinfo_documents = [
 
 
 intersphinx_mapping = {
-    "flask": ("http://flask.pocoo.org/docs/", None),
-    "python": ("http://docs.python.org/", None),
-    "werkzeug": ("http://werkzeug.pocoo.org/docs/", None),
+    "flask": ("https://flask.palletsprojects.com/", None),
+    "python": ("https://docs.python.org/", None),
+    "werkzeug": ("https://werkzeug.palletsprojects.com/", None),
 }

--- a/doc/errors.rst
+++ b/doc/errors.rst
@@ -141,8 +141,8 @@ that you can do with Flask/Blueprint :meth:`@errorhandler <flask:flask.Flask.err
     @api.errorhandler(RootException)
     def handle_root_exception(error):
         '''Return a custom message and 400 status code'''
-        return {'message': 'What you want'}, 400       
-        
+        return {'message': 'What you want'}, 400
+
 
     @api.errorhandler(CustomException)
     def handle_custom_exception(error):
@@ -160,14 +160,14 @@ that you can do with Flask/Blueprint :meth:`@errorhandler <flask:flask.Flask.err
     def handle_fake_exception_with_header(error):
         '''Return a custom message and 400 status code'''
         return {'message': error.message}, 400, {'My-Header': 'Value'}
-        
-        
+
+
     @api.errorhandler(NoResultFound)
     def handle_no_result_exception(error):
         '''Return a custom not found error message and 404 status code'''
-        return {'message': error.specific}, 404        
-        
-        
+        return {'message': error.specific}, 404
+
+
 .. note ::
 
     A "NoResultFound" error with description is required by the OpenAPI 2.0 spec. The docstring in the error handle function is output in the swagger.json as the description.

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -1,7 +1,7 @@
 Full example
 ============
 
-Here is a full example of a `TodoMVC <http://todomvc.com/>`_ API.
+Here is a full example of a `TodoMVC <https://todomvc.com/>`_ API.
 
 .. code-block:: python
 

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -56,7 +56,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/doc/parsing.rst
+++ b/doc/parsing.rst
@@ -8,7 +8,7 @@ Request Parsing
     The whole request parser part of Flask-RESTX is slated for removal and
     will be replaced by documentation on how to integrate with other packages
     that do the input/output stuff better
-    (such as `marshmallow <http://marshmallow.readthedocs.org>`_).
+    (such as `marshmallow <https://marshmallow.readthedocs.io/>`_).
     This means that it will be maintained until 2.0 but consider it deprecated.
     Don't worry, if you have code using that now and wish to continue doing so,
     it's not going to go away any time too soon.

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -5,7 +5,7 @@ Quick start
 
 .. currentmodule:: flask_restx
 
-This guide assumes you have a working understanding of `Flask <http://flask.pocoo.org>`_,
+This guide assumes you have a working understanding of `Flask <https://flask.palletsprojects.com/>`_,
 and that you have already installed both Flask and Flask-RESTX.
 If not, then follow the steps in the :ref:`installation` section.
 
@@ -82,7 +82,7 @@ A minimal Flask-RESTX API looks like this:
 
 
 Save this as api.py and run it using your Python interpreter.
-Note that we've enabled `Flask debugging <http://flask.pocoo.org/docs/quickstart/#debug-mode>`_
+Note that we've enabled `Flask debugging <https://flask.palletsprojects.com/quickstart/#debug-mode>`_
 mode to provide code reloading and better error messages.
 
 .. code-block:: console
@@ -152,7 +152,7 @@ You can try it like this:
     {"todo2": "Change my brakepads"}
 
 
-Or from python if you have the `Requests <http://docs.python-requests.org/>`_ library installed:
+Or from python if you have the `Requests <https://docs.python-requests.org/>`_ library installed:
 
 .. code-block:: python
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -23,13 +23,15 @@ All you need to do is update your requirements to use Flask-RESTX instead of
 Flask-RESTPlus. Then you need to update all your imports.
 This can be done using something like:
 
-::
+.. code-block:: bash
+
    find . -type f -name "*.py" | xargs sed -i "s/flask_restplus/flask_restx/g"
 
 Finally, you will need to update your configuration options (described `here
-<quickstart.html#configuration>`_). Example:
+<configuration.html>`_). Example:
 
-::
+.. code-block:: bash
+
    find . -type f -name "*.py" | xargs sed -i "s/RESTPLUS_/RESTX_/g"
 
 
@@ -112,7 +114,7 @@ See :ref:`swaggerui` for a complete documentation on the automatic documentation
 Resourceful Routing
 -------------------
 The main building block provided by Flask-RESTX are resources.
-Resources are built on top of :ref:`Flask pluggable views <flask:views>`,
+Resources are built on top of :doc:`Flask pluggable views <flask:views>`,
 giving you easy access to multiple HTTP methods just by defining methods on your resource.
 A basic CRUD resource for a todo application (of course) looks like this:
 

--- a/doc/scaling.rst
+++ b/doc/scaling.rst
@@ -38,7 +38,7 @@ Here's an example directory structure::
 
 
 The `app` module will serve as a main application entry point following one of the classic
-Flask patterns (See :ref:`flask:larger-applications` and :ref:`flask:app-factories`).
+Flask patterns (See :doc:`flask:patterns/packages` and :doc:`flask:patterns/appfactories`).
 
 The `core` module is an example, it contains the business logic.
 In fact, you call it whatever you want, and there can be many packages.
@@ -151,7 +151,7 @@ Using this pattern, you simply have to register your API in `app.py` like that:
 Use With Blueprints
 -------------------
 
-See :ref:`blueprints` in the Flask documentation for what blueprints are and why you should use them.
+See :doc:`flask:blueprints` in the Flask documentation for what blueprints are and why you should use them.
 Here's an example of how to link an :class:`Api` up to a :class:`~flask.Blueprint`.
 
 .. code-block:: python

--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -1067,4 +1067,4 @@ To disable Swagger UI entirely, set ``doc=False``:
     api = Api(app, doc=False)
 
 
-.. _vendor extensions: http://swagger.io/specification/#specification-extensions-128
+.. _vendor extensions: https://swagger.io/specification/#specification-extensions

--- a/flask_restx/cors.py
+++ b/flask_restx/cors.py
@@ -17,7 +17,7 @@ def crossdomain(
     credentials=False,
 ):
     """
-    http://flask.pocoo.org/snippets/56/
+    https://web.archive.org/web/20190128010149/http://flask.pocoo.org/snippets/56/
     """
     if methods is not None:
         methods = ", ".join(sorted(x.upper() for x in methods))

--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -480,7 +480,7 @@ class Swagger(object):
         """
         Extract custom 3rd party Vendor fields prefixed with ``x-``
 
-        See: http://swagger.io/specification/#specification-extensions-128
+        See: https://swagger.io/specification/#specification-extensions
         """
         return dict(
             (k if k.startswith("x-") else "x-{0}".format(k), v)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ PYPI_RST_FILTERS = (
     # replace doc references
     (
         r":doc:`(.+) <(.*)>`",
-        r"`\1 <http://flask-restx.readthedocs.org/en/stable\2.html>`_",
+        r"`\1 <https://flask-restx.readthedocs.io/en/stable\2.html>`_",
     ),
     # replace issues references
     (


### PR DESCRIPTION
I fixed a bunch of documentation link problems.

Flask's doc is now hosted at https://flask.palletsprojects.com/ and its documentation was updated, rendering multiple intersphinx mappings broken.
Many other URLs in docs were using http instead of https and some links were broken or didn't lead to where they should have.
The quickstart section to migrate from restplus to restx didn't render the two bash commands in code blocks.
PyInvoke's link in CONTRIBUTING was using the markdown syntax instead of RST and was broken.

I tested all the suggested changes :slightly_smiling_face: 

:man_juggling: :snake: 