### PR TITLE
#313 don't use werkzeug, flask 2.0.0 and use Response instead of BaseResponse

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -34,7 +34,13 @@ from werkzeug.exceptions import (
     NotAcceptable,
     InternalServerError,
 )
-from werkzeug.wrappers import BaseResponse
+
+from werkzeug import __version__ as werkzeug_version
+
+if werkzeug_version.split('.')[0] >= '2':
+    from werkzeug.wrappers import Response as BaseResponse
+else:
+    from werkzeug.wrappers import BaseResponse
 
 from . import apidoc
 from .mask import ParseError, MaskError

--- a/flask_restx/resource.py
+++ b/flask_restx/resource.py
@@ -3,7 +3,12 @@ from __future__ import unicode_literals
 
 from flask import request
 from flask.views import MethodView
-from werkzeug.wrappers import BaseResponse
+from werkzeug import __version__ as werkzeug_version
+
+if werkzeug_version.split('.')[0] >= '2':
+    from werkzeug.wrappers import Response as BaseResponse
+else:
+    from werkzeug.wrappers import BaseResponse
 
 from .model import ModelBase
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,8 +1,8 @@
 aniso8601==8.0.0; python_version < '3.5'
 aniso8601>=0.82; python_version >= '3.5'
 jsonschema
-Flask>=0.8, <2.0.0
-werkzeug <2.0.0
+Flask>=0.8, !=2.0.0
+werkzeug !=2.0.0
 pytz
 six>=1.3.0
 enum34; python_version < '3.4'


### PR DESCRIPTION
This code imports `BaseResponse` if version of `werkzeug` is less than 2.0.0 otherwise it imports `Response` as suggested.
In addition to that, it forbids `werkzeug` and `flask` version `2.0.0` because description of `HttpException` becomes `None` and it fails the tests. This behavior is fixed in version `2.0.1`, so users still can use version `2.0.1`. @j5awry I know changes are short but could you take a look at it? Or, is the repo waiting for more people to report breaking changes? In that case, could you let us know when that period will end? 