### PR TITLE
Do not call got_request_exception for exceptions explicitly handled

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -679,8 +679,6 @@ class Api(object):
         :param Exception e: the raised Exception object
 
         """
-        got_request_exception.send(current_app._get_current_object(), exception=e)
-
         # When propagate_exceptions is set, do not return the exception to the
         # client if a handler is configured for the exception.
         if (
@@ -710,6 +708,10 @@ class Api(object):
                 )
                 break
         else:
+            # Flask docs say: "This signal is not sent for HTTPException or other exceptions that have error handlers
+            # registered, unless the exception was raised from an error handler."
+            got_request_exception.send(current_app._get_current_object(), exception=e)
+
             if isinstance(e, HTTPException):
                 code = HTTPStatus(e.code)
                 if include_message_in_response:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -444,6 +444,27 @@ class ErrorsTest(object):
         finally:
             got_request_exception.disconnect(record, app)
 
+    def test_handle_error_signal_does_not_call_got_request_exception(self, app):
+        api = restx.Api(app)
+
+        exception = BadRequest()
+
+        recorded = []
+
+        def record(sender, exception):
+            recorded.append(exception)
+
+        @api.errorhandler(BadRequest)
+        def handle_bad_request(error):
+          return {"message": str(error), "value": "test"}, 400
+
+        got_request_exception.connect(record, app)
+        try:
+            api.handle_error(exception)
+            assert len(recorded) == 0
+        finally:
+            got_request_exception.disconnect(record, app)
+
     def test_handle_error(self, app):
         api = restx.Api(app)
 


### PR DESCRIPTION
Cherry-picked the changes by @chandlernine from #294 and added a test in test_errors.py as advised.