### PR TITLE
Corrected spelling of swagger.json file in API documentation

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -532,7 +532,7 @@ class Api(object):
         """
         The Swagger specifications relative url (ie. `swagger.json`). If
         the spec_url_scheme attribute is set, then the full url is provided instead
-        (e.g. http://localhost/swaggger.json).
+        (e.g. http://localhost/swagger.json).
 
         :rtype: str
         """


### PR DESCRIPTION
Correction to swagger file naming in API documentation