### PR TITLE
Fix: Working outside of request context

### DIFF
--- a/flask_restx/marshalling.py
+++ b/flask_restx/marshalling.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from functools import wraps
 from six import iteritems
 
-from flask import request, current_app, has_app_context
+from flask import request, current_app, has_app_context, has_request_context
 
 from .mask import Mask, apply as apply_mask
 from .utils import unpack
@@ -247,7 +247,7 @@ class marshal_with(object):
         def wrapper(*args, **kwargs):
             resp = f(*args, **kwargs)
             mask = self.mask
-            if has_app_context():
+            if has_app_context() and has_request_context():
                 mask_header = current_app.config["RESTX_MASK_HEADER"]
                 mask = request.headers.get(mask_header) or mask
             if isinstance(resp, tuple):


### PR DESCRIPTION

RuntimeError: Working outside of application context.

This typically means that you attempted to use functionality that
needed to interface with the current application object in some way.
To solve this, set up an application context with app.app_context().

https://github.com/python-restx/flask-restx/blob/master/flask_restx/marshalling.py#L251 --> this line is protected by `has_app_context`
https://github.com/python-restx/flask-restx/blob/master/flask_restx/marshalling.py#L252 --> this line is not protected by `has_request_context`

I have integrated marshal_with serializer to database SQLAlchemy models But getting the  **RuntimeError: Working outside of request context**

Corrected the code and successfully ran tox tests.