### PR TITLE
wildcard string None fix

### DIFF
--- a/flask_restx/marshalling.py
+++ b/flask_restx/marshalling.py
@@ -88,9 +88,9 @@ def marshal(data, fields, envelope=None, skip_none=False, mask=None, ordered=Fal
                     _append(key, value)
                     while True:
                         value = field.output(dkey, data, ordered=ordered)
-                        if value is None or value == field.container.format(
+                        if value is None or (field.default is not None and value == field.container.format(
                             field.default
-                        ):
+                        )):
                             break
                         key = field.key
                         _append(key, value)

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -87,6 +87,15 @@ class MarshallingTest(object):
         output = marshal(marshal_dict, model, skip_none=True)
         assert output == {"foo": "bar"}
 
+    def test_marshal_wildcard_none_str(self):
+        wild = fields.Wildcard(fields.String)
+        model = OrderedDict([("*", wild)])
+        marshal_dict = OrderedDict(
+            [("a", "None"), ("b", "tata")]
+        )
+        output = marshal(marshal_dict, model)
+        assert output == {"a": "None", "b": "tata"}
+
     def test_marshal_wildcard_with_skip_none(self):
         wild = fields.Wildcard(fields.String)
         model = OrderedDict([("foo", fields.Raw), ("*", wild)])


### PR DESCRIPTION
This fixes the problem where a data value is the word `"None"`. `six.text_type(None)` returns `"None"` in `String.format()`. Please the unit test for more info. Thanks!