### PR TITLE
Add tests and contributing doc to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
-include README.rst MANIFEST.in LICENSE
+include README.rst MANIFEST.in LICENSE CONTRIBUTING.rst
 recursive-include flask_restx *
 recursive-include requirements *.pip
+recursive-include tests *
 
 global-exclude *.pyc


### PR DESCRIPTION
These are helpful for downstream packaging. Adding tests allows
tests to be run within a distribution while building the package.

Fixes #375