### PR TITLE
Fix typo in docs, in quickstart.rst

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -219,7 +219,7 @@ You can also match parts of the path as variables to your resource methods.
     # or
 
     @api.route('/todo/<int:todo_id>', endpoint='todo_ep')
-    class HelloWorld(Resource):
+    class Todo(Resource):
         pass
 
 .. note ::


### PR DESCRIPTION
this commit fixes the class name typo in the Endpoints second example code.

'HelloWorld' -> 'Todo'
