### PR TITLE
Fixed handle_error method

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -701,6 +701,8 @@ class Api(object):
         )
         default_data = {}
 
+        result = None
+
         headers = Headers()
 
         for typecheck, handler in six.iteritems(self._own_and_child_error_handlers):
@@ -735,7 +737,7 @@ class Api(object):
         if include_message_in_response:
             default_data["message"] = default_data.get("message", str(e))
 
-        data = getattr(e, "data", default_data)
+        data = getattr(result, "data", default_data)
         fallback_mediatype = None
 
         if code >= HTTPStatus.INTERNAL_SERVER_ERROR:


### PR DESCRIPTION
Fixed issue related to topic 'Exception data is returned instead of custom error handle data'. 
Related issues: 
python-restx#33 
python-restx#27 
python-restx#103
python-restx#102

Now it first looks for an error message from your custom error_handler, if there is none, it will return the default_data.