### PR TITLE
Fix multiform bug

### DIFF
--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -466,7 +466,7 @@ class Swagger(object):
         doc_params = list(doc.get("params", {}).values())
         all_params = doc_params + (operation["parameters"] or [])
         if all_params and any(p["in"] == "formData" for p in all_params):
-            if any(p["type"] == "file" for p in all_params):
+            if any(p["type"] == "file" or (p["type"]=="array" and p["collectionFormat"]=="multi") for p in all_params):
                 operation["consumes"] = ["multipart/form-data"]
             else:
                 operation["consumes"] = [

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -769,6 +769,25 @@ class SwaggerTest(object):
         assert "consumes" in op
         assert op["consumes"] == ["multipart/form-data"]
 
+    def test_parser_parameter_in_files_appended(self, api, client):
+        parser = api.parser()
+        parser.add_argument(
+            "in_files", type=FileStorage, location="files", action="append"
+        )
+
+        @api.route("/with-parser/", endpoint="with-parser")
+        class WithParserResource(restx.Resource):
+            @api.expect(parser)
+            def post(self):
+                return {}
+
+        data = client.get_specs()
+        assert "/with-parser/" in data["paths"]
+
+        path = data["paths"]["/with-parser/"]
+        op = path["post"]
+        assert op["consumes"][0] == "multipart/form-data"
+
     def test_explicit_parameters(self, api, client):
         @api.route("/name/<int:age>/", endpoint="by-name")
         class ByNameResource(restx.Resource):
@@ -1028,7 +1047,11 @@ class SwaggerTest(object):
             "/name/<int:age>/",
             endpoint="by-name",
             doc={
-                "get": {"params": {"q": "A query string",}},
+                "get": {
+                    "params": {
+                        "q": "A query string",
+                    }
+                },
                 "params": {"age": "An age"},
             },
         )


### PR DESCRIPTION
This PR fixes the bug where Swagger does _not_ interpreting an API consuming an array of files, as requiring the request to be a multipart-form. Others have reflected this problem, e.g. #177.

To fix this, this PR makes the following changes over 2 commits.
- First, expand test-suite to account for an array of files. If this test-suite had been expanded, the original codebase would have failed the test.
- Second, edit `swagger.py` to fix the bug. This passes the expanded test suite above.