### PR TITLE
Update quickstart.rst

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -206,7 +206,8 @@ Each one will be routed to your :class:`~Resource`:
 
     # or
 
-    @api.route('/hello', '/world')
+    @api.route('/hello')
+    @api.route('/world')
     class HelloWorld(Resource):
         pass
 


### PR DESCRIPTION
Fixes a TypeError when defining two endpoints in one routing declaration
```
@api.route('/hello', '/world')
class HelloWorld(Resource):
    pass
```
> TypeError: Scaffold.route() takes 2 positional arguments but 3 were given

This works:
```
@api.route('/hello')
@api.route('/world')
class HelloWorld(Resource):
    pass
```