### PR TITLE
align to newer Flask version

### DIFF
--- a/tests/legacy/test_api_legacy.py
+++ b/tests/legacy/test_api_legacy.py
@@ -379,7 +379,10 @@ class APITest(object):
 
         resp = client.get("/api")
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "http://localhost/"
+        if flask.__version__ >= "2.1.0":
+            assert resp.headers["Location"] == "/"
+        else:
+            assert resp.headers["Location"] == "http://localhost/"
 
     def test_calling_owns_endpoint_before_api_init(self):
         api = restx.Api()


### PR DESCRIPTION
in Flask 2.1.0 redirects remain relative https://flask.palletsprojects.com/en/2.1.x/changes/