### PR TITLE
Fix #460 - missing parse_rule method

### DIFF
--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -89,8 +89,11 @@ def extract_path(path):
 
 def parse_rule(rule):
     """
-    This originally lived in werkzeug.routing.parse_rule until it was removed in werkzeug 2.2.0. Copying it here to
-    avoid depending on the older version of werkzeug.
+    Parse a rule and return it as generator. Each iteration yields tuples in the form
+    ``(converter, arguments, variable)``. If the converter is `None` it's a static url part, otherwise it's a dynamic
+    one.
+
+    Note: This originally lived in werkzeug.routing.parse_rule until it was removed in werkzeug 2.2.0.
     """
     pos = 0
     end = len(rule)


### PR DESCRIPTION
## What's this all about?
This is an attempt to fix issue #460, where werkzeug used to expose a function `werkzeug.routing.parse_rule` but made it private as of werkzeug==2.2.0.

The method was extracted from [this change](https://github.com/pallets/werkzeug/commit/5a7c0dec029d296a5e8131c8db51ce19e28c0c58#diff-f353ec8ecb0bad3d3c6527734c587a80fc81c8cc4a8002b13242a06c8c9f6dddL83-L112) which seems to be when it was fully removed from werkzeug.

Copying it into this project because the method is self-contained. One alternative would be to pin the werkzeug version, which isn't a terrible idea, but also means this project would miss out on future werkzeug improvements. 🤷 Neither option is great but copy-paste is simple so that's what I did.

## What's next before this can merge?
* ❌ Right now the `ossaudit` check is failing, which prevents the other checks from running. It is not clear to me how to fix the failing tests. For example, it seems to be complaining that there is vulnerability in the latest version of flask. Which is good to know but unfixable:
```
+------------+---------+----------------------------------------------------+
|    name    | version |                       title                        |
+============+=========+====================================================+
| setuptools | 56.0.0  | 1 vulnerability found                              |
+------------+---------+----------------------------------------------------+
| pip        | 22.2.1  | [CVE-20[18](https://github.com/python-restx/flask-restx/runs/7569430787?check_suite_focus=true#step:5:19)-20225] CWE-20: Improper Input Validation |
+------------+---------+----------------------------------------------------+
| Flask      | 2.1.3   | 1 vulnerability found                              |
+------------+---------+----------------------------------------------------+
| dparse     | 0.5.1   | 1 vulnerability found                              |
+------------+---------+----------------------------------------------------+
Found 4 vulnerabilities in 73 packages
```
* ✅ The black syntax check is passing when I run locally.
* ❌ Tests are failing. There appears to be another, unrelated issue from werkzeug which broke the tests.