### PR TITLE
Add missing dependency on `six`

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -2,5 +2,6 @@ aniso8601==8.0.0; python_version < '3.5'
 aniso8601>=0.82; python_version >= '3.5'
 jsonschema
 Flask>=0.8, !=2.0.0
+six
 werkzeug !=2.0.0
 pytz


### PR DESCRIPTION
Somewhere in the last day we started getting these errors when trying
to update our requirements lock file:

    foo.py:9: in <module>
        from flask_restx import fields, Namespace
    ../internal_pip_dependency_flask_restx_3_7/pypi__flask_restx/flask_restx/__init__.py:2: in <module>
        from .api import Api  # noqa
    ../internal_pip_dependency_flask_restx_3_7/pypi__flask_restx/flask_restx/api.py:45: in <module>
        from .postman import PostmanCollectionV1
    ../internal_pip_dependency_flask_restx_3_7/pypi__flask_restx/flask_restx/postman.py:7: in <module>
        from six import iteritems
    E   ModuleNotFoundError: No module named 'six'

The problem is that `flask-restx` doesn't declare a dependency on
`six`. That causes our system not to pull it into the sandbox.

The fix is to declare `six` as a dependency.