### PR TITLE
document api.doc parameter description via dict

### DIFF
--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -28,6 +28,16 @@ You can document a class or a method:
         def post(self, id):
             api.abort(403)
 
+If you want a finer control, nested dicts could also be used:
+
+.. code-block:: python
+
+    @api.route('/my-resource/<id>', endpoint='my-resource')
+    @api.doc(params={'id': {'description': 'An ID', 'required': 'true', 'default': ''}})
+    class MyResource(Resource):
+        def get(self, id):
+            return {}
+
 
 Automatically documented models
 -------------------------------


### PR DESCRIPTION
Have lost few hours before stumbled upon solution (https://github.com/python-restx/flask-restx/issues/139) for describing parameters inside `api.doc` decorator via `dict`. Wanted to to spare the time for the next one searching.