### PR TITLE
Fix UserWarning on Flask 2.2.0

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -229,6 +229,8 @@ class Api(object):
         self.license_url = kwargs.get("license_url", self.license_url)
         self.url_scheme = kwargs.get("url_scheme", self.url_scheme)
         self._add_specs = kwargs.get("add_specs", True)
+        self._register_specs(app)
+        self._register_doc(app)
 
         # If app is a blueprint, defer the initialization
         try:
@@ -245,9 +247,6 @@ class Api(object):
 
         :param flask.Flask app: The flask application object
         """
-        self._register_specs(self.blueprint or app)
-        self._register_doc(self.blueprint or app)
-
         app.handle_exception = partial(self.error_router, app.handle_exception)
         app.handle_user_exception = partial(
             self.error_router, app.handle_user_exception


### PR DESCRIPTION
Flask 2.2.0 issues a warning if a url rule is added to a blueprint after it has been registered, so this commit ensures that the documentation rules are added before the blueprint is registered.

Fixes: #485