### PR TITLE
Fix propagate_exceptions deprecation warning

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -686,7 +686,7 @@ class Api(object):
         # client if a handler is configured for the exception.
         if (
             not isinstance(e, HTTPException)
-            and current_app.propagate_exceptions
+            and current_app.config.get("PROPAGATE_EXCEPTIONS", False)
             and not isinstance(e, tuple(self._own_and_child_error_handlers.keys()))
         ):
 


### PR DESCRIPTION
Using the current flask_restx codebase against Flask 2.2.0 raises the following warning:

   DeprecationWarning: 'propagate_exceptions' is deprecated and will be removed in Flask 2.3

This commit fixes the warning by getting PROPAGATE_EXCEPTIONS straight from the config settings.