### PR TITLE
Fix actions tidy up tox

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,5 +6,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.8"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -38,16 +38,16 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Checkout ${{ github.base_ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.base_ref}}
           path: base
       - name: Checkout ${{ github.ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref}}
           path: ref

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.8"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,18 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
+.. _section-1.0.3:
+1.0.3
+-----
+
+.. _bug_fixes-1.0.3
+Bug Fixes
+~~~~~~~~~
+
+::
+
+   * Fix failing pypy python setup in github actions.
+
 .. _section-1.0.2:
 1.0.2
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,17 +25,17 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
-.. _section-1.0.3:
-1.0.3
+.. _section-1.0.4:
+1.0.4
 -----
 
-.. _bug_fixes-1.0.3
+.. _bug_fixes-1.0.4
 Bug Fixes
 ~~~~~~~~~
 
 ::
 
-   * Fix failing pypy python setup in github actions.
+   * Fix failing pypy python setup in github actions
 
 .. _section-1.0.2:
 1.0.2

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ and expose its documentation properly using `Swagger`_.
 Compatibility
 =============
 
-Flask-RESTX requires Python 3.5+.
+Flask-RESTX requires Python 3.7+.
 
 On Flask Compatibility
 ======================

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{37, 38, 39, 310}, pypy3, doc
+envlist = py{37, 38, 39, 310}, pypy3.8, doc
 
 [testenv]
 commands = {posargs:inv test qa}


### PR DESCRIPTION
Fix failing pypy install on github actions after `ubuntu:latest` was updated to be Ubuntu 22.04. 

This needs to be merged before https://github.com/python-restx/flask-restx/pull/500 as the checks don't currently pass. 