### PR TITLE
One further changes to fix propagate exceptions.

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -673,6 +673,18 @@ class Api(object):
                 return original_handler(f)
         return original_handler(e)
 
+    def _propagate_exceptions(self):
+        """
+        Returns the value of the ``PROPAGATE_EXCEPTIONS`` configuration
+        value in case it's set, otherwise return true if app.debug or
+        app.testing is set. This method was deprecated in Flask 2.3 but
+        we still need it for our error handlers.
+        """
+        rv = current_app.config.get("PROPAGATE_EXCEPTIONS")
+        if rv is not None:
+            return rv
+        return current_app.testing or current_app.debug
+
     def handle_error(self, e):
         """
         Error handler for the API transforms a raised exception into a Flask response,
@@ -685,10 +697,7 @@ class Api(object):
         # client if a handler is configured for the exception.
         if (
             not isinstance(e, HTTPException)
-            and (
-                current_app.config.get("PROPAGATE_EXCEPTIONS")
-                or (current_app.testing or current_app.debug)
-            )
+            and self._propagate_exceptions()
             and not isinstance(e, tuple(self._own_and_child_error_handlers.keys()))
         ):
             exc_type, exc_value, tb = sys.exc_info()


### PR DESCRIPTION
Despite my fix, some testing showed it was still incorrect because the user couldn't override app.testing or app.debug if they didn't want to propagate exceptions. This simply copies the flask implementation as is instead. 