### PR TITLE
Add python 3 11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,8 @@ Bug Fixes
 
    * Update Black to 2023 version [peter-doggart]
    * Fix minor bug introduced in 1.0.5 that changed the behaviour of how flask-restx propagates exceptions. (#512) [peter-doggart]
+   * Update PyPi classifer to Production/Stable. [peter-doggart]
+   * Add support for Python 3.11 (requires update to invoke ^2.0.0) [peter-doggart]
 
 .. _section-1.0.5:
 1.0.5

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -8,5 +8,5 @@ pytest-flask==1.2.0
 pytest-mock==3.6.1
 pytest-profiling==1.7.0
 tzlocal
-invoke==1.7.3
+invoke==2.0.0
 twine==3.8.0

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     zip_safe=False,
     keywords="flask restx rest api swagger openapi",
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python",
         "Environment :: Web Environment",
         "Operating System :: OS Independent",
@@ -106,6 +106,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{37, 38, 39, 310}, pypy3.8, doc
+envlist = py{37, 38, 39, 310, 311}, pypy3.8, doc
 
 [testenv]
 commands = {posargs:inv test qa}


### PR DESCRIPTION
This PR adds Python 3.11 suppport. No code changes required, just updates to the github actions and test framework. 