### PR TITLE
Added support for empty JSON arguments

### DIFF
--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -214,7 +214,8 @@ def build_request_body_parameters_schema(body_params):
 
     properties = {}
     for param in body_params:
-        properties[param["name"]] = {"type": param.get("type", "string")}
+        if body_params[0]["name"] is not None:
+            properties[param["name"]] = {"type": param.get("type", "string")}
 
     return {
         "name": "payload",


### PR DESCRIPTION
Adds support for empty JSON body inputs in the generated Swagger documentation:

![image](https://user-images.githubusercontent.com/30942843/219701293-3556ceab-99f2-4fa0-b611-3fd0f1c4cf4d.png)

The code is essentially just ignoring any arguments with a `None` name, so if it is the sole argument you can have an empty input:

```
empty_json_parser = RequestParser()
empty_json_parser.add_argument(None, location="json")
```

If there is a better way to do this or it is already supported, please let me know!