### PR TITLE
Update docs root route

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Bug Fixes
 
    * Update Swagger-UI to latest version to fix several security vulnerabiltiies. [peter-doggart]
    * Add a warning to the docs that nested Blueprints are not supported. [peter-doggart]
+   * Add a note to the docs that flask-restx always registers the root (/) path. [peter-doggart]
 
 .. _section-1.0.6:
 1.0.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,11 +25,11 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
-.. _section-1.0.7:
-1.0.7
+.. _section-1.1.0:
+1.1.0
 -----
 
-.. _bug_fixes-1.0.7
+.. _bug_fixes-1.1.0
 Bug Fixes
 ~~~~~~~~~
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -110,6 +110,12 @@ You can also use the automatic documentation on you API root (by default).
 In this case: http://127.0.0.1:5000/.
 See :ref:`swaggerui` for a complete documentation on the automatic documentation.
 
+.. note ::
+    Initializing the :class:`~Api` object always registers the root endpoint ``/`` 
+    even if the :ref:`swaggerui` path is changed. If you which to use the root 
+    endpoint ``/`` for other purposes, you must register it before initializing 
+    the :class:`~Api` object.
+
 
 Resourceful Routing
 -------------------

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -112,7 +112,7 @@ See :ref:`swaggerui` for a complete documentation on the automatic documentation
 
 .. note ::
     Initializing the :class:`~Api` object always registers the root endpoint ``/`` 
-    even if the :ref:`swaggerui` path is changed. If you which to use the root 
+    even if the :ref:`swaggerui` path is changed. If you wish to use the root 
     endpoint ``/`` for other purposes, you must register it before initializing 
     the :class:`~Api` object.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flask-restx",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Fully featured framework for fast, easy and documented API development with Flask",
   "repository": "python-restx/flask-restx",
   "keywords": [


### PR DESCRIPTION
Add a note to the quick-start docs about registering the `/` route since it seems to come up on issues quiet often. 