### PR TITLE
Pass init kwargs to init_app

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -196,8 +196,7 @@ class Api(object):
         self.url_scheme = url_scheme
         if app is not None:
             self.app = app
-            self.init_app(app)
-        # super(Api, self).__init__(app, **kwargs)
+            self.init_app(app, **kwargs)
 
     def init_app(self, app, **kwargs):
         """


### PR DESCRIPTION
I noticed that `__init__`'s kwargs are currently unused while `init_app` could use for additional configurations which could added upon object initialization in case an app or blueprint instance added along with them.

Also I removed that old commented super call.