### PR TITLE
Strip only the first occurence of summary from details

### DIFF
--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -160,7 +160,7 @@ def parse_docstring(obj):
     raw = getdoc(obj)
     summary = raw.strip(" \n").split("\n")[0].split(".")[0] if raw else None
     raises = {}
-    details = raw.replace(summary, "").lstrip(". \n").strip(" \n") if raw else None
+    details = raw.lstrip(summary).lstrip(". \n").strip(" \n") if raw else None
     for match in RE_RAISES.finditer(raw or ""):
         raises[match.group("name")] = match.group("description")
         if details:


### PR DESCRIPTION
If we have the following method docstring

    """
    Create a package
    Create a package inside your project. And now diving deep into the details...
    """

Then IMHO the expected behavior is "Create a package" displayed as a summary and
the rest displayed as _details_. That's not what happens using `raw.replace`,
the result is now only "inside your project. And now diving deep into the
details..."