### PR TITLE
Issue 177

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,13 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
+.. _section-1.2.0:
+1.2.0
+-----
+.._bug_fixes-1.2.0
+Bug Fixes
+Fixing issue #177 to allow file list uploads, whilst other arugments are present. 
+
 .. _section-1.1.0:
 1.1.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ on the Changelog!
 .. _section-1.2.0:
 1.2.0
 -----
-.._bug_fixes-1.2.0
+.. _bug_fixes-1.2.0
 Bug Fixes
 Fixing issue #177 to allow file list uploads, whilst other arugments are present. 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,11 @@ on the Changelog!
 -----
 .. _bug_fixes-1.2.0
 Bug Fixes
-Fixing issue #177 to allow file list uploads, whilst other arugments are present. 
+~~~~~~~~~
+
+::
+
+   * Fixing issue #177 to allow file list uploads, whilst other arugments are present. 
 
 .. _section-1.1.0:
 1.1.0

--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -504,6 +504,9 @@ class Swagger(object):
         if all_params and any(p["in"] == "formData" for p in all_params):
             if any(p["type"] == "file" for p in all_params):
                 operation["consumes"] = ["multipart/form-data"]
+            elif any(p["type"] == "array" and p["collectionFormat"] == "multi" for p in all_params
+                     if "collectionFormat" in p):
+                operation["consumes"] = ["multipart/form-data"]
             else:
                 operation["consumes"] = [
                     "application/x-www-form-urlencoded",


### PR DESCRIPTION
Updates to allow files lists, using the action="append" argument in the parser. Adds unit tests to confirm that this works, not only whilst the file list is present, but when other arguments are alongside the file list in a single form.