### PR TITLE
issue-547 http header quality factor number

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,18 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
+.. _section-1.1.1:
+1.1.0
+-----
+.. _bug_fixes-1.1.1
+Bug Fixes
+~~~~~~~~~
+
+::
+
+   * Fixing test as HTTP Header MIMEAccept expects quality-factor number in form of `X.X` (#547) [chipndell]
+
+
 .. _section-1.1.0:
 1.1.0
 -----

--- a/tests/legacy/test_api_legacy.py
+++ b/tests/legacy/test_api_legacy.py
@@ -108,7 +108,7 @@ class APITest(object):
         api = restx.Api(app)
 
         with app.test_request_context(
-            "/foo", headers={"Accept": "application/xml; q=.5"}
+            "/foo", headers={"Accept": "application/xml; q=0.5"}
         ):
             assert api.mediatypes_method()(mocker.Mock()) == [
                 "application/xml",
@@ -119,7 +119,8 @@ class APITest(object):
         api = restx.Api(app)
 
         with app.test_request_context(
-            "/foo", headers={"Accept": "application/json; q=1, application/xml; q=.5"}
+            "/foo",
+            headers={"Accept": "application/json; q=1.0, application/xml; q=0.5"},
         ):
             assert api.mediatypes() == ["application/json", "application/xml"]
 


### PR DESCRIPTION
## Proposed changes

Change in Werkzeug 2.3.5 as [issued here](https://github.com/pallets/werkzeug/issues/2716) caused the fail in build. As per [HTTP RFC](https://www.rfc-editor.org/rfc/rfc9110#section-12.5.1) the quality-factor for HTTP Accept Header has to be like `X.X`. So changing them all to such format, all Unit tests and Tox test passes.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [guidelines for contributing](https://github.com/python-restx/flask-restx/blob/master/CONTRIBUTING.rst)
- [X] All unit tests pass on my local version with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Fixes #547 