### PR TITLE
Fix typo in doc/marshalling.rst

### DIFF
--- a/doc/marshalling.rst
+++ b/doc/marshalling.rst
@@ -232,7 +232,7 @@ use :class:`~fields.Wildcard` ::
     >>> '{"Jane": "68", "bob": "42", "John": "12"}'
 
 The name you give to your :class:`~fields.Wildcard` acts as a real glob as
-shown bellow ::
+shown below ::
 
     >>> from flask_restx import fields, marshal
     >>> import json


### PR DESCRIPTION
This commit fixes a typo in the `Wildcard` section in Response marshalling