### PR TITLE
Drop support for python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.8"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,16 +25,26 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
-.. _section-1.1.1:
-1.1.0
+.. _section-1.2.0:
+1.2.0
 -----
-.. _bug_fixes-1.1.1
+.. _bug_fixes-1.2.0
 Bug Fixes
 ~~~~~~~~~
 
 ::
 
    * Fixing test as HTTP Header MIMEAccept expects quality-factor number in form of `X.X` (#547) [chipndell]
+
+
+.. _enhancements-1.2.0:
+
+Enhancements
+~~~~~~~~~~~~
+
+::
+
+   * Drop support for python 3.7
 
 
 .. _section-1.1.0:

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ and expose its documentation properly using `Swagger`_.
 Compatibility
 =============
 
-Flask-RESTX requires Python 3.7+.
+Flask-RESTX requires Python 3.8+.
 
 On Flask Compatibility
 ======================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,7 +33,7 @@ development and to support our users.
 Compatibility
 =============
 
-Flask-RESTX requires Python 3.7+.
+Flask-RESTX requires Python 3.8+.
 
 
 Installation

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -20,5 +20,5 @@ The development version can be downloaded from
     pip install -e .[dev,test]
 
 
-Flask-RESTX requires Python version 2.7, 3.5, 3.6, 3.7, or 3.8.
+Flask-RESTX requires Python version 3.8+.
 It's also working with PyPy and PyPy3.

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
         "Topic :: System :: Software Distribution",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{37, 38, 39, 310, 311}, pypy3.8, doc
+envlist = py{38, 39, 310, 311}, pypy3.8, doc
 
 [testenv]
 commands = {posargs:inv test qa}


### PR DESCRIPTION
As discussed in #553 Python 3.7 is EOL and can be dropped. 

I saw one remark considering old python versions that need some attention I guess but can be addressed in a different PR. 

https://github.com/python-restx/flask-restx/blob/b1e5d192261abbae91a67b1cfb29f16d53540ec3/setup.cfg#L15C4-L19