### PR TITLE
Replace pkg_resources with importlib_resources

### DIFF
--- a/flask_restx/schemas/__init__.py
+++ b/flask_restx/schemas/__init__.py
@@ -6,7 +6,8 @@ and allows to validate specs against them.
 """
 import io
 import json
-import pkg_resources
+
+import importlib_resources
 
 from collections.abc import Mapping
 from jsonschema import Draft4Validator
@@ -56,8 +57,9 @@ class LazySchema(Mapping):
 
     def _load(self):
         if not self._schema:
-            filename = pkg_resources.resource_filename(__name__, self.filename)
-            with io.open(filename) as infile:
+            ref = importlib_resources.files(__name__) / self.filename
+
+            with io.open(ref) as infile:
                 self._schema = json.load(infile)
 
     def __getitem__(self, key):

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -3,3 +3,4 @@ jsonschema
 Flask>=0.8, !=2.0.0
 werkzeug !=2.0.0
 pytz
+importlib_resources


### PR DESCRIPTION
In preparation to support Python 3.12 pkg_resources need to be removed. 

According to there migration guide it can be replaced by `importlib_resources`

https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename