### PR TITLE
Fix wrong status code and message on responses when handling `HTTPException`s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Bug Fixes
 ::
 
    * Fixing test as HTTP Header MIMEAccept expects quality-factor number in form of `X.X` (#547) [chipndell]
+   * Fix wrong status code and message on responses when handling `HTTPExceptions` (#569) [lkk7]
 
 
 .. _enhancements-1.2.0:

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -732,7 +732,7 @@ class Api(object):
                 elif e.response is not None:
                     code = HTTPStatus(e.response.status_code)
                 if include_message_in_response:
-                    default_data = {"message": getattr(e, "description", code.phrase)}
+                    default_data = {"message": e.description or code.phrase}
                 headers = e.get_response().headers
             elif self._default_error_handler:
                 result = self._default_error_handler(e)

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -726,7 +726,11 @@ class Api(object):
             got_request_exception.send(current_app._get_current_object(), exception=e)
 
             if isinstance(e, HTTPException):
-                code = HTTPStatus(e.code)
+                code = None
+                if e.code is not None:
+                    code = HTTPStatus(e.code)
+                elif e.response is not None:
+                    code = HTTPStatus(e.response.status_code)
                 if include_message_in_response:
                     default_data = {"message": getattr(e, "description", code.phrase)}
                 headers = e.get_response().headers

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -7,7 +7,13 @@ from flask import Blueprint, abort
 from flask.signals import got_request_exception
 
 from werkzeug import Response
-from werkzeug.exceptions import HTTPException, BadRequest, NotFound, Aborter
+from werkzeug.exceptions import (
+    Aborter,
+    BadRequest,
+    HTTPException,
+    NotFound,
+    Unauthorized,
+)
 from werkzeug.http import quote_etag, unquote_etag
 
 import flask_restx as restx
@@ -646,15 +652,15 @@ class ErrorsTest(object):
         assert response.status_code == 500
         assert json.loads(response.data.decode()) == {"foo": "bar"}
 
-    def test_handle_error_http_exception_code(self, app):
+    def test_handle_error_http_exception_response_code_only(self, app):
         api = restx.Api(app)
         http_exception = HTTPException(response=Response(status=401))
 
         response = api.handle_error(http_exception)
         assert response.status_code == 401
-        # assert json.loads(response.data.decode()) == {
-        #     "message": BadRequest.description,
-        # }
+        assert json.loads(response.data.decode()) == {
+            "message": "Unauthorized",
+        }
 
     def test_errorhandler_swagger_doc(self, app, client):
         api = restx.Api(app)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,6 +6,7 @@ import pytest
 from flask import Blueprint, abort
 from flask.signals import got_request_exception
 
+from werkzeug import Response
 from werkzeug.exceptions import HTTPException, BadRequest, NotFound, Aborter
 from werkzeug.http import quote_etag, unquote_etag
 
@@ -644,6 +645,16 @@ class ErrorsTest(object):
         response = api.handle_error(exception)
         assert response.status_code == 500
         assert json.loads(response.data.decode()) == {"foo": "bar"}
+
+    def test_handle_error_http_exception_code(self, app):
+        api = restx.Api(app)
+        http_exception = HTTPException(response=Response(status=401))
+
+        response = api.handle_error(http_exception)
+        assert response.status_code == 401
+        # assert json.loads(response.data.decode()) == {
+        #     "message": BadRequest.description,
+        # }
 
     def test_errorhandler_swagger_doc(self, app, client):
         api = restx.Api(app)


### PR DESCRIPTION
Fixes https://github.com/python-restx/flask-restx/issues/569.

All details are in the issue.
The code fixes both of the issues:

Feel free to edit the PR to match your expectations ☺️ 

- [X] Formatted
- [X] Tests passing
 