### PR TITLE
fix: BaseResponse import - replace wekzeug import  __version__ by importlib (#573)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Bug Fixes
 ::
 
    * Fixing test as HTTP Header MIMEAccept expects quality-factor number in form of `X.X` (#547) [chipndell]
+   * Fixing werkzeug 3 deprecated version import. Import is replaced by new style version check with importlib (#573) [Ryu-CZ]
 
 
 .. _enhancements-1.2.0:

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -32,20 +32,13 @@ from werkzeug.exceptions import (
     InternalServerError,
 )
 
-from werkzeug import __version__ as werkzeug_version
-
-if werkzeug_version.split(".")[0] >= "2":
-    from werkzeug.wrappers import Response as BaseResponse
-else:
-    from werkzeug.wrappers import BaseResponse
-
 from . import apidoc
 from .mask import ParseError, MaskError
 from .namespace import Namespace
 from .postman import PostmanCollectionV1
 from .resource import Resource
 from .swagger import Swagger
-from .utils import default_id, camel_to_dash, unpack
+from .utils import default_id, camel_to_dash, unpack, BaseResponse
 from .representations import output_json
 from ._http import HTTPStatus
 

--- a/flask_restx/resource.py
+++ b/flask_restx/resource.py
@@ -1,15 +1,10 @@
 from flask import request
 from flask.views import MethodView
-from werkzeug import __version__ as werkzeug_version
 
-if werkzeug_version.split(".")[0] >= "2":
-    from werkzeug.wrappers import Response as BaseResponse
-else:
-    from werkzeug.wrappers import BaseResponse
 
 from .model import ModelBase
 
-from .utils import unpack
+from .utils import unpack, BaseResponse
 
 
 class Resource(MethodView):

--- a/flask_restx/utils.py
+++ b/flask_restx/utils.py
@@ -17,7 +17,27 @@ __all__ = (
     "not_none",
     "not_none_sorted",
     "unpack",
+    "BaseResponse",
 )
+
+
+def import_werkzeug_response():
+    """Resolve `werkzeug` `Response` class import because
+    `BaseResponse` was renamed in version 2.* to `Response`"""
+    import importlib.metadata
+
+    werkzeug_major = int(importlib.metadata.version("werkzeug").split()[0])
+    if werkzeug_major < 2:
+        from werkzeug.wrappers import BaseResponse
+
+        return BaseResponse
+
+    from werkzeug.wrappers import Response
+
+    return Response
+
+
+BaseResponse = import_werkzeug_response()
 
 
 def merge(first, second):

--- a/flask_restx/utils.py
+++ b/flask_restx/utils.py
@@ -26,7 +26,7 @@ def import_werkzeug_response():
     `BaseResponse` was renamed in version 2.* to `Response`"""
     import importlib.metadata
 
-    werkzeug_major = int(importlib.metadata.version("werkzeug").split()[0])
+    werkzeug_major = int(importlib.metadata.version("werkzeug").split(".")[0])
     if werkzeug_major < 2:
         from werkzeug.wrappers import BaseResponse
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,11 @@ class MergeTestCase(object):
         assert utils.merge(a, b) == b
 
 
+class UnpackImportResponse(object):
+    def test_import_werkzeug_response(self):
+        assert utils.import_werkzeug_response() != None
+
+
 class CamelToDashTestCase(object):
     def test_no_transform(self):
         assert utils.camel_to_dash("test") == "test"


### PR DESCRIPTION
Fix for removed `wekzeug.__version__` #573 and  Logical follow up to replacement of pkg_resources replacement  #562 . 

**_Design decision_**: I decided to create separate import function `import_werkzeug_response` to do not mess up with global import space with `import werkzeug` in case of future version conflicts.  `BaseResponse` is now imported once within `flask_restx.utils` module internally with method `import_werkzeug_response` and  accessible as `flask_restx.utils.BaseResponse` .