### PR TITLE
Add flask 2 (<3.0) and flask 3 (>=3.0) to test matrix and do not fast fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,10 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.8"]
+        flask: ["<3.0.0", ">=3.0.0"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -25,6 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install "flask${{ matrix.flask }}"
           pip install ".[test]"
       - name: Test with inv
         run: inv cover qa

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{38, 39, 310, 311}, pypy3.8, doc
+envlist =
+    py{38, 39, 310, 311}-flask2,
+    py{311}-flask3
+    pypy3.8
+    doc
 
 [testenv]
 commands = {posargs:inv test qa}
 deps =
+    flask2: flask<3.0.0
+    flask3: flask>=3.0.0
     -r{toxinidir}/requirements/test.pip
     -r{toxinidir}/requirements/develop.pip
 


### PR DESCRIPTION
To get more insight if our fixes are working for both flask version I created a test-matrix for flask 2 (<3.0.0) & flask 3 (>=3.0.0)