### PR TITLE
Note flask 3.0 compatibility is in progress in README. (#566)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Flask and Werkzeug moved to versions 2.0 in March 2020. This caused a breaking c
       - < 2.0.0
       - pinned in Flask-RESTX.
     * - >= 0.5.0
-      - All (For Now)
+      - < 3.0.0 (For Now: see https://github.com/python-restx/flask-restx/issues/566)
       - unpinned, import statements wrapped for compatibility
     * - trunk branch in Github
       - All (and updated more often)


### PR DESCRIPTION
Here's a quick change to the README that notes the current compatibility status of Flask 3.0 while all of you wonderful people work on getting that up to date.