### PR TITLE
Introduce temporary package version restrictions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Bug Fixes
 ::
 
    * Fixing test as HTTP Header MIMEAccept expects quality-factor number in form of `X.X` (#547) [chipndell]
+   * Introduce temporary restrictions on some package versions. (`flask<3.0.0`, `werkzeug<3.0.0`, `jsonschema<=4.17.3`) [peter-doggart]
+   * Introduce temporary dependency on a personal fork of `pytest-flask` until upstream fixes compatibility with `flask>=3.0.0` [peter-doggart]
 
 
 .. _enhancements-1.2.0:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,6 @@ Bug Fixes
 
    * Fixing test as HTTP Header MIMEAccept expects quality-factor number in form of `X.X` (#547) [chipndell]
    * Introduce temporary restrictions on some package versions. (`flask<3.0.0`, `werkzeug<3.0.0`, `jsonschema<=4.17.3`) [peter-doggart]
-   * Introduce temporary dependency on a personal fork of `pytest-flask` until upstream fixes compatibility with `flask>=3.0.0` [peter-doggart]
 
 
 .. _enhancements-1.2.0:

--- a/README.rst
+++ b/README.rst
@@ -60,10 +60,10 @@ Flask and Werkzeug moved to versions 2.0 in March 2020. This caused a breaking c
       - < 2.0.0
       - pinned in Flask-RESTX.
     * - >= 0.5.0
-      - All (For Now)
+      - < 3.0.0
       - unpinned, import statements wrapped for compatibility
     * - trunk branch in Github
-      - All (and updated more often)
+      - < 3.0.0 (Flask >=3.0.0 support is in progress, see https://github.com/python-restx/flask-restx/issues/566)
       - unpinned, will address issues faster than releases.
 
 Installation

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,6 +1,6 @@
 aniso8601>=0.82
-jsonschema
-Flask>=0.8, !=2.0.0
-werkzeug !=2.0.0
+jsonschema<=4.17.3
+Flask>=0.8, !=2.0.0, <3.0.0
+werkzeug!=2.0.0, <3.0.0
 pytz
 importlib_resources

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -4,7 +4,7 @@ mock==3.0.5
 pytest==7.0.1
 pytest-benchmark==3.4.1
 pytest-cov==4.0.0
-pytest-flask==1.2.0
+git+https://github.com/peter-doggart/pytest-flask-temp.git@remove-request-ctx#egg=pytest-flask
 pytest-mock==3.6.1
 pytest-profiling==1.7.0
 tzlocal

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -4,7 +4,7 @@ mock==3.0.5
 pytest==7.0.1
 pytest-benchmark==3.4.1
 pytest-cov==4.0.0
-pytest-flask@git+https://github.com/peter-doggart/pytest-flask-temp.git@remove-request-ctx
+pytest-flask==1.2.0
 pytest-mock==3.6.1
 pytest-profiling==1.7.0
 tzlocal

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -4,7 +4,7 @@ mock==3.0.5
 pytest==7.0.1
 pytest-benchmark==3.4.1
 pytest-cov==4.0.0
-git+https://github.com/peter-doggart/pytest-flask-temp.git@remove-request-ctx#egg=pytest-flask
+pytest-flask@git+https://github.com/peter-doggart/pytest-flask-temp.git@remove-request-ctx
 pytest-mock==3.6.1
 pytest-profiling==1.7.0
 tzlocal


### PR DESCRIPTION
This PR introduces a temporary restriction on flask, werkzeug and jsonschema packages until we can get everything updated. 

It was my intention to temporarily point the pytest-flask installation to a fork that included the 3.0.0 fixes until they are merged upstream. However, the pipeline installs via setuptools and the `pip()` function in `setup.py` strips out pip git checkout links. 