### PR TITLE
Prepare release 1.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,10 +25,10 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
-.. _section-1.2.1:
-1.2.1
+.. _section-1.3.0:
+1.3.0
 -----
-.. _bug_fixes-1.2.1
+.. _bug_fixes-1.3.0
 Bug Fixes
 ~~~~~~~~~
 
@@ -37,7 +37,12 @@ Bug Fixes
    * Fixing werkzeug 3 deprecated version import. Import is replaced by new style version check with importlib (#573) [Ryu-CZ]
    * Fixing flask 3.0+ compatibility of `ModuleNotFoundError: No module named 'flask.scaffold'` Import error. (#567) [Ryu-CZ]
    * Fix wrong status code and message on responses when handling `HTTPExceptions` (#569) [lkk7]
-
+   * Add flask 2 and flask 3 to testing matrix. [foarsitter]
+   * Update internally pinned pytest-flask to 1.3.0 for Flask >3.0.0 support. [peter-doggart]
+   * Python 3.12 support. [foarsitter]
+   * Fix wrong status code and message on responses when handling HTTPExceptions. [ikk7]
+   * Update changelog Flask version table. [peter-doggart]
+   * Remove temporary package version restrictions for flask < 3.0.0, werkzeug and jsonschema (jsonschema future deprecation warning remains. See #553). [peter-doggart]
 
 .. _section-1.2.0:
 1.2.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,7 @@ Bug Fixes
    * Fixing flask 3.0+ compatibility of `ModuleNotFoundError: No module named 'flask.scaffold'` Import error. (#567) [Ryu-CZ]
    * Fix wrong status code and message on responses when handling `HTTPExceptions` (#569) [lkk7]
    * Add flask 2 and flask 3 to testing matrix. [foarsitter]
-   * Update internally pinned pytest-flask to 1.3.0 for Flask >3.0.0 support. [peter-doggart]
+   * Update internally pinned pytest-flask to 1.3.0 for Flask >=3.0.0 support. [peter-doggart]
    * Python 3.12 support. [foarsitter]
    * Fix wrong status code and message on responses when handling HTTPExceptions. [ikk7]
    * Update changelog Flask version table. [peter-doggart]

--- a/README.rst
+++ b/README.rst
@@ -66,10 +66,10 @@ Flask and Werkzeug moved to versions 2.0 in March 2020. This caused a breaking c
       - < 3.0.0
       - pinned in Flask-RESTX.
     * - >= 1.3.0
-      - >= 2.0.0 (Flask > 3.0.0 support)
+      - >= 2.0.0 (Flask >= 3.0.0 support)
       - unpinned, import statements wrapped for compatibility
     * - trunk branch in Github
-      - >= 2.0.0 (Flask > 3.0.0 support)
+      - >= 2.0.0 (Flask >= 3.0.0 support)
       - unpinned, will address issues faster than releases.
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,14 @@ Flask and Werkzeug moved to versions 2.0 in March 2020. This caused a breaking c
     * - >= 0.5.0
       - < 3.0.0
       - unpinned, import statements wrapped for compatibility
+    * - == 1.2.0
+      - < 3.0.0
+      - pinned in Flask-RESTX.
+    * - >= 1.3.0
+      - >= 2.0.0 (Flask > 3.0.0 support)
+      - unpinned, import statements wrapped for compatibility
     * - trunk branch in Github
-      - < 3.0.0 (Flask >=3.0.0 support is in progress, see https://github.com/python-restx/flask-restx/issues/566)
+      - >= 2.0.0 (Flask > 3.0.0 support)
       - unpinned, will address issues faster than releases.
 
 Installation

--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -757,7 +757,7 @@ Documenting authorizations
 You can use the ``authorizations`` keyword argument to document authorization information.
 See `Swagger Authentication documentation <https://swagger.io/docs/specification/2-0/authentication/>`_
 for configuration details.
-    - ``authorizations`` is a Python dictionary representation of the Swagger ``securityDefinitions`` configuration.
+- ``authorizations`` is a Python dictionary representation of the Swagger ``securityDefinitions`` configuration.
 
 .. code-block:: python
 

--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -34,7 +34,13 @@ from .namespace import Namespace
 from .postman import PostmanCollectionV1
 from .resource import Resource
 from .swagger import Swagger
-from .utils import default_id, camel_to_dash, unpack, import_check_view_func, BaseResponse
+from .utils import (
+    default_id,
+    camel_to_dash,
+    unpack,
+    import_check_view_func,
+    BaseResponse,
+)
 from .representations import output_json
 from ._http import HTTPStatus
 

--- a/flask_restx/utils.py
+++ b/flask_restx/utils.py
@@ -42,6 +42,7 @@ def import_werkzeug_response():
 
 BaseResponse = import_werkzeug_response()
 
+
 class FlaskCompatibilityWarning(DeprecationWarning):
     pass
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flask-restx",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "Fully featured framework for fast, easy and documented API development with Flask",
   "repository": "python-restx/flask-restx",
   "keywords": [

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,6 +1,6 @@
 aniso8601>=0.82
-jsonschema<=4.17.3
-Flask>=0.8, !=2.0.0, <3.0.0
-werkzeug!=2.0.0, <3.0.0
+jsonschema
+Flask>=0.8, !=2.0.0
+werkzeug!=2.0.0
 pytz
 importlib_resources

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -4,7 +4,7 @@ mock==3.0.5
 pytest==7.0.1
 pytest-benchmark==3.4.1
 pytest-cov==4.0.0
-pytest-flask==1.2.0
+pytest-flask==1.3.0
 pytest-mock==3.6.1
 pytest-profiling==1.7.0
 tzlocal

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
This PR provides the final updates to enable Flask >= 3.0.0 support. 