### PR TITLE
Fix potential undefined variable in swagger-ui.html (#565)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,18 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
+.. _section-1.3.1:
+1.3.1
+-----
+.. _bug_fixes-1.3.1
+Bug Fixes
+~~~~~~~~~
+
+::
+
+   * Add jinja test for potentially undefined variable in `swagger-ui.html`. Compatibility with jinja's StrictUndefined mode. (#565) [sloschert]
+  
+
 .. _section-1.3.0:
 1.3.0
 -----

--- a/flask_restx/templates/swagger-ui.html
+++ b/flask_restx/templates/swagger-ui.html
@@ -51,7 +51,7 @@
         window.onload = function() {
             const ui = window.ui = new SwaggerUIBundle({
                 url: "{{ specs_url }}",
-                {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}
+                {% if config.SWAGGER_UI_OAUTH_CLIENT_ID is defined and config.SWAGGER_UI_OAUTH_CLIENT_ID -%}
                 oauth2RedirectUrl: "{{ url_for('restx_doc.static', filename='oauth2-redirect.html', _external=True) }}",
                 {%- endif %}
                 validatorUrl: "{{ config.SWAGGER_VALIDATOR_URL }}" || null,
@@ -71,7 +71,7 @@
                 docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"
             })
 
-            {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}
+            {% if config.SWAGGER_UI_OAUTH_CLIENT_ID is defined and config.SWAGGER_UI_OAUTH_CLIENT_ID  -%}
             ui.initOAuth({
                 clientId: "{{ config.SWAGGER_UI_OAUTH_CLIENT_ID }}",
                 realm: "{{ config.SWAGGER_UI_OAUTH_REALM }}",


### PR DESCRIPTION
* Add jinja test for potentially undefined variable in `swagger-ui.html`. Compatibility with jinja's StrictUndefined mode.

* Add CHANGELOG.rst entry

fixes #565 