### PR TITLE
Add the OpenAPI definitions to the validation schema for resolving JSON pointers

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -16,8 +16,6 @@ from flask import make_response as original_flask_make_response
 
 from flask.signals import got_request_exception
 
-from jsonschema import RefResolver
-
 from werkzeug.utils import cached_property
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import (
@@ -162,7 +160,6 @@ class Api(object):
         )
         self._schema = None
         self.models = {}
-        self._refresolver = None
         self.format_checker = format_checker
         self.namespaces = []
         self.default_swagger_filename = default_swagger_filename
@@ -821,12 +818,6 @@ class Api(object):
     def payload(self):
         """Store the input payload in the current request context"""
         return request.get_json()
-
-    @property
-    def refresolver(self):
-        if not self._refresolver:
-            self._refresolver = RefResolver.from_schema(self.__schema__)
-        return self._refresolver
 
     @staticmethod
     def _blueprint_setup_add_url_rule_patch(

--- a/flask_restx/model.py
+++ b/flask_restx/model.py
@@ -16,7 +16,6 @@ from jsonschema.exceptions import ValidationError
 from .utils import not_none
 from ._http import HTTPStatus
 
-
 RE_REQUIRED = re.compile(r"u?\'(?P<name>.*)\' is a required property", re.I | re.U)
 
 
@@ -88,10 +87,10 @@ class ModelBase(object):
         model.__parents__ = parents[:-1]
         return model
 
-    def validate(self, data, resolver=None, format_checker=None):
-        validator = Draft4Validator(
-            self.__schema__, resolver=resolver, format_checker=format_checker
-        )
+    def validate(self, data, format_checker=None, definitions=None):
+        schema = self.__schema__
+        schema["definitions"] = definitions or {}
+        validator = Draft4Validator(schema, format_checker=format_checker)
         try:
             validator.validate(data)
         except ValidationError:

--- a/flask_restx/resource.py
+++ b/flask_restx/resource.py
@@ -65,9 +65,17 @@ class Resource(MethodView):
         if collection:
             data = data if isinstance(data, list) else [data]
             for obj in data:
-                expect.validate(obj, self.api.refresolver, self.api.format_checker)
+                expect.validate(
+                    obj,
+                    self.api.format_checker,
+                    definitions=self.api.__schema__["definitions"],
+                )
         else:
-            expect.validate(data, self.api.refresolver, self.api.format_checker)
+            expect.validate(
+                data,
+                self.api.format_checker,
+                definitions=self.api.__schema__["definitions"],
+            )
 
     def validate_payload(self, func):
         """Perform a payload validation on expected model if necessary"""


### PR DESCRIPTION
This PR fixes #553 (reopens #560). 

The `referencing` library isn't required when the complete definition is present in schema. 

