### PR TITLE
Add python version requirement on setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,18 @@ Releases prior to 0.3.0 were “best effort” filled out, but are missing
 some info. If you see your contribution missing info, please open a PR
 on the Changelog!
 
+.. _section-1.3.1:
+1.3.1
+-----
+.. _bug_fixes-1.3.1
+Bug Fixes
+~~~~~~~~~
+
+::
+
+   * Add python version requirement on setup.py (#586) [jason-the-j]
+
+
 .. _section-1.3.0:
 1.3.0
 -----

--- a/setup.py
+++ b/setup.py
@@ -111,4 +111,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",
     ],
+    python_requires=">=3.8"
 )


### PR DESCRIPTION
**Problem:**
All python versions previous to 3.8 are now end of life and no longer supported.
But, pip automatically installs the latest version of flask_restx on python 3.6 (or any version under 3.8), resulting in ModuleNotFoundError on importlib.metadata which is available starting with python 3.8.

**Solution:**
include python_requires option when setup for pip to resolve python dependency accordingly. 
prevent installing the latest and unsupported flask_restx regardless of python version. 
fixes #586

