### PR TITLE
Fix #613

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Basic structure is
     ADD LINK (..) _section-VERSION
     VERSION
     -------
-    ADD LINK (..) _bug_fixes-VERSION OR _enhancments-VERSION
+    ADD LINK (..) _bug_fixes-VERSION OR _enhancements-VERSION
     Bug Fixes or Enchancements
     ~~~~~~~~~~~~~~~~~~~~~~~~~~
     * Message (TICKET) [CONTRIBUTOR]
@@ -35,7 +35,7 @@ Bug Fixes
 ::
 
    * Add python version requirement on setup.py (#586) [jason-the-j]
-
+   * Register models nested inside response fields (#613) [panda-byte]
 
 .. _section-1.3.0:
 1.3.0

--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -680,6 +680,7 @@ class Swagger(object):
             return self.serialize_schema(model())
 
         elif isinstance(model, fields.Raw):
+            self.register_field(model)
             return model.__schema__
 
         elif isinstance(model, (type, type(None))) and model in PY_TYPES:
@@ -704,6 +705,12 @@ class Swagger(object):
         return ref(model)
 
     def register_field(self, field):
+        """
+        Traverse a "container" field (`Nested`, `List`, `Wildcard`,
+        and `Polymorph`) and register any nested models. Used for
+        models nested inside other models or responses using fields
+        for definition.
+        """
         if isinstance(field, fields.Polymorph):
             for model in field.mapping.values():
                 self.register_model(model)


### PR DESCRIPTION
Fix #613. When using e.g. `fields.List` for response structures, any models nested inside are now correctly registered.