### PR TITLE
fix: :bug: Shortcuts can silently collide and overwrite end-points.

### DIFF
--- a/flask_restx/namespace.py
+++ b/flask_restx/namespace.py
@@ -7,7 +7,7 @@ from flask import request
 from flask.views import http_method_funcs
 
 from ._http import HTTPStatus
-from .errors import abort
+from .errors import abort, ValidationError
 from .marshalling import marshal, marshal_with
 from .model import Model, OrderedModel, SchemaModel
 from .reqparse import RequestParser
@@ -15,7 +15,7 @@ from .utils import merge
 
 # Container for each route applied to a Resource using @ns.route decorator
 ResourceRoute = namedtuple("ResourceRoute", "resource urls route_doc kwargs")
-
+DOC_IDS = [] # List all document ids used.
 
 class Namespace(object):
     """
@@ -129,6 +129,9 @@ class Namespace(object):
     def doc(self, shortcut=None, **kwargs):
         """A decorator to add some api documentation to the decorated object"""
         if isinstance(shortcut, str):
+            if shortcut in DOC_IDS:
+                raise ValidationError("Doc description already in use by another method!")
+            DOC_IDS.append(shortcut)
             kwargs["id"] = shortcut
         show = shortcut if isinstance(shortcut, bool) else True
 


### PR DESCRIPTION
Shortcuts can silently collide and overwrite end-points, generating incorrect swagger documentation.

The following example is incorrectly generating the swagger document:

![image](https://github.com/user-attachments/assets/128c9b1f-534a-4bdb-9ae2-206fc692b281)

If you press the first get method all the methods having the same doc will expand at the same time:

![image](https://github.com/user-attachments/assets/ab0219a3-a40a-4459-a77d-10ee5787b683)

![image](https://github.com/user-attachments/assets/eb6d8336-91e2-4b34-b94e-c7c6267f356b)

It should raise a ValidationError with the proposed fixed as follows:

![image](https://github.com/user-attachments/assets/8d9022a2-a204-46a1-950b-f33fc60bb412)