### PR TITLE
Fixed failed unit tests caused by using `pytz` inappropriately

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from datetime import date, datetime
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from functools import partial
 
@@ -8,6 +8,9 @@ import pytest
 
 from flask import Blueprint
 from flask_restx import fields, Api
+
+
+_CET_TIMEZONE = timezone(timedelta(hours=1), "CET")
 
 
 class FieldTestCase(object):
@@ -542,7 +545,7 @@ class DatetimeFieldTest(BaseFieldTestMixin, FieldTestCase):
                 "Sat, 01 Jan 2011 23:59:59 -0000",
             ),
             (
-                datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone("CET")),
+                datetime(2011, 1, 1, 23, 59, 59, tzinfo=_CET_TIMEZONE),
                 "Sat, 01 Jan 2011 22:59:59 -0000",
             ),
         ],
@@ -566,7 +569,7 @@ class DatetimeFieldTest(BaseFieldTestMixin, FieldTestCase):
                 "2011-01-01T23:59:59.001000+00:00",
             ),
             (
-                datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone("CET")),
+                datetime(2011, 1, 1, 23, 59, 59, tzinfo=_CET_TIMEZONE),
                 "2011-01-01T23:59:59+01:00",
             ),
         ],
@@ -676,7 +679,7 @@ class DateFieldTest(BaseFieldTestMixin, FieldTestCase):
             (datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.utc), "2011-01-01"),
             (datetime(2011, 1, 1, 23, 59, 59, 1000, tzinfo=pytz.utc), "2011-01-01"),
             (
-                datetime(2011, 1, 1, 23, 59, 59, tzinfo=pytz.timezone("CET")),
+                datetime(2011, 1, 1, 23, 59, 59, tzinfo=_CET_TIMEZONE),
                 "2011-01-01",
             ),
         ],


### PR DESCRIPTION
As per the document https://pythonhosted.org/pytz/ :

`Unfortunately using the tzinfo argument of the standard datetime constructors 'does not work' with pytz for many timezones`.

This fixes https://github.com/python-restx/flask-restx/issues/620