### PR TITLE
Fix testing for Flask 3.1.0 changes.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.8", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "pypy3.9", "3.12"]
         flask: ["<3.0.0", ">=3.0.0"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Checkout ${{ github.base_ref }}
         uses: actions/checkout@v3
         with:

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ and expose its documentation properly using `Swagger`_.
 Compatibility
 =============
 
-Flask-RESTX requires Python 3.8+.
+Flask-RESTX requires Python 3.9+.
 
 On Flask Compatibility
 ======================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,7 +33,7 @@ development and to support our users.
 Compatibility
 =============
 
-Flask-RESTX requires Python 3.8+.
+Flask-RESTX requires Python 3.9+.
 
 
 Installation

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -20,5 +20,5 @@ The development version can be downloaded from
     pip install -e .[dev,test]
 
 
-Flask-RESTX requires Python version 3.8+.
+Flask-RESTX requires Python version 3.9+.
 It's also working with PyPy and PyPy3.

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
         "Topic :: System :: Software Distribution",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -111,5 +110,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ class TestClient(FlaskClient):
 
 @pytest.fixture
 def app():
-    app = Flask(__name__)
+    app = Flask(__name__, subdomain_matching=True)
     app.test_client_class = TestClient
     yield app
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@
 
 [tox]
 envlist =
-    py{38, 39, 310, 311}-flask2,
+    py{39, 310, 311}-flask2,
     py{311, 312}-flask3
-    pypy3.8
+    pypy3.9
     doc
 
 [testenv]


### PR DESCRIPTION
Flask 3.1.0 introduced changes on subdomains which caused some tests to fail. See https://github.com/pallets/flask/issues/5553 

This PR re-enables the functionality to be the same as previously. 