### PR TITLE
use flask machinery for json

### DIFF
--- a/flask_restx/representations.py
+++ b/flask_restx/representations.py
@@ -1,9 +1,5 @@
-try:
-    from ujson import dumps
-except ImportError:
-    from json import dumps
-
 from flask import make_response, current_app
+from flask.json import dumps
 
 
 def output_json(data, code, headers=None):

--- a/tests/legacy/test_api_legacy.py
+++ b/tests/legacy/test_api_legacy.py
@@ -334,14 +334,10 @@ class APITest(object):
         assert data == expected
 
     def test_use_custom_jsonencoder(self, app, client):
-        class CabageEncoder(JSONEncoder):
-            def default(self, obj):
-                return "cabbage"
+        def default(obj):
+            return "cabbage"
 
-        class TestConfig(object):
-            RESTX_JSON = {"cls": CabageEncoder}
-
-        app.config.from_object(TestConfig)
+        app.json.default = default
         api = restx.Api(app)
 
         class Cabbage(restx.Resource):

--- a/tests/test_custom_json.py
+++ b/tests/test_custom_json.py
@@ -1,0 +1,45 @@
+import json
+import pytest
+
+from flask.json.provider import JSONProvider
+from flask_restx import Api, Resource
+
+from datetime import datetime
+
+
+class CustomJSONTest(object):
+    @pytest.mark.parametrize("provider", ["json", "ujson", "sdjson"])
+    def test_custom_json(self, app, client, provider):
+        provmod = pytest.importorskip(provider)
+        class CustomJSONProvider(JSONProvider):
+            def dumps(self, obj, **kwargs):
+                extra = {"serializer": provmod.__name__}
+                return provmod.dumps(
+                    obj | extra,
+                    default=CustomJSONProvider._default,
+                    **kwargs
+                )
+
+            def loads(self, s, **kwargs):
+                extra = {"deserializer": provmod.__name__}
+                return provmod.loads(s, **kwargs) | extra
+
+            @staticmethod
+            def _default(obj):
+                if isinstance(obj, datetime):
+                    return obj.isoformat()
+                return super().default(obj)
+
+        app.json_provider_class = CustomJSONProvider
+        app.json = app.json_provider_class(app)
+        api = Api(app)
+
+        @api.route("/test")
+        class TestResource(Resource):
+            def post(self):
+                return api.payload, 200
+
+        resp = client.post("/test", json={"name": "tester"})
+        assert resp.status_code == 200
+        assert json.loads(resp.data.decode("utf-8"))["serializer"] == provmod.__name__
+        assert json.loads(resp.data.decode("utf-8"))["deserializer"] == provmod.__name__


### PR DESCRIPTION
`flask-restx` lacks of ability to switch JSON [de]serializer.
I prepared small patch to use `flask` machinery for JSON.

Usage example:
```python
import logging
from datetime import datetime

import sdjson

from flask import Flask, current_app
from flask.json.provider import JSONProvider
from flask_restx import Api, Resource

logging.basicConfig(level=logging.INFO)


class SDJSONProvider(JSONProvider):
    def dumps(self, obj, **kwargs):
        current_app.logger.info("SDJSONProvider.dumps()")
        return sdjson.dumps(obj, default=str)

    def loads(self, s, **kwargs):
        current_app.logger.info("SDJSONProvider.loads()")
        return sdjson.loads(s, **kwargs)


class MyApp(Flask):
    json_provider_class = SDJSONProvider


app = MyApp(__name__)
api = Api(app)


@api.route("/date")
class DateResource(Resource):
    def get(self):
        return {"current_date": datetime.now()}


if __name__ == "__main__":
    app.run(debug=True)
```

another usage example:
```python
import logging
from datetime import datetime

import sdjson

from flask import Flask, current_app
from flask.json.provider import JSONProvider
from flask_restx import Api, Resource, fields

logging.basicConfig(level=logging.INFO)


class SDJSONProvider(JSONProvider):
    def dumps(self, obj, **kwargs):
        current_app.logger.info("SDJSONProvider.dumps()")
        return sdjson.dumps(obj, default=SDJSONProvider._default)

    def loads(self, s, **kwargs):
        current_app.logger.info("SDJSONProvider.loads()")
        return sdjson.loads(s, **kwargs)

    @staticmethod
    def _default(obj):
        if isinstance(obj, datetime):
            return obj.isoformat()
        return super().default(obj)


app = Flask(__name__)
app.json = SDJSONProvider(app)
api = Api(app)

hello_model = api.model(
    "Hello", {"name": fields.String(required=True, description="Your name")}
)


@api.route("/hello")
@api.expect(hello_model)
class HelloResource(Resource):
    def post(self):
        current_app.logger.info(api.payload)
        name = api.payload["name"]
        return (
            {
                "response": f"Hello, {name}!",
                "current_date": datetime.now(),
            },
            201,
        )


if __name__ == "__main__":
    app.run(debug=True)
```
