### PR TITLE
Swagger: add summary on method documentation

### DIFF
--- a/flask_restx/reqparse.py
+++ b/flask_restx/reqparse.py
@@ -309,7 +309,10 @@ class Argument(object):
             param["type"] = "array"
             param["collectionFormat"] = "csv"
         if self.choices:
-            param["enum"] = self.choices
+            if param.get("collectionFormat", None) == "csv" or param.get("collectionFormat", None) == "multi":
+                param["items"]["enum"] = self.choices
+            else:
+                param["enum"] = self.choices
         return param
 
 

--- a/flask_restx/swagger.py
+++ b/flask_restx/swagger.py
@@ -486,7 +486,7 @@ class Swagger(object):
     def serialize_operation(self, doc, method):
         operation = {
             "responses": self.responses_for(doc, method) or None,
-            "summary": doc[method]["docstring"]["summary"],
+            "summary": self.summary_for( doc, method) or None,
             "description": self.description_for(doc, method) or None,
             "operationId": self.operation_id_for(doc, method),
             "parameters": self.parameters_for(doc[method]) or None,
@@ -522,6 +522,18 @@ class Swagger(object):
             (k if k.startswith("x-") else "x-{0}".format(k), v)
             for k, v in doc[method].get("vendor", {}).items()
         )
+
+    def summary_for(self, doc, method):
+        """Extract the summay metadata and fallback on the whole docstring"""
+        parts = []
+        if "summary" in doc:
+            parts.append(doc["summary"] or "")
+        if method in doc and "summary" in doc[method]:
+            parts.append(doc[method]["summary"])
+        if doc[method]["docstring"]["summary"]:
+            parts.append(doc[method]["docstring"]["summary"])
+
+        return "\n".join(parts).strip()
 
     def description_for(self, doc, method):
         """Extract the description metadata and fallback on the whole docstring"""


### PR DESCRIPTION
Implements a mean to add the summary of a method with api.doc decorator.
This change is suggested by https://github.com/albinpopote

#109 