### PR TITLE
A fix to allow nullable fields.nested for input validation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ Bug Fixes
 ::
 
    * Add python version requirement on setup.py (#586) [jason-the-j]
-
+   * Fix Nested field schema generation for nullable fields. (#638) [peter-doggart]
 
 .. _section-1.3.0:
 1.3.0

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -881,6 +881,17 @@ class NestedFieldTest(FieldTestCase):
         assert field.allow_null
         assert field.__schema__ == {"$ref": "#/definitions/NestedModel"}
 
+    def test_with_nullable_schema(self, api):
+        nested_fields = api.model("NestedModel", {"name": fields.String})
+        field = fields.Nested(nested_fields, nullable=True)
+        # Should allow null in schema via anyOf
+        assert field.__schema__ == {
+            "anyOf": [
+                {"$ref": "#/definitions/NestedModel"},
+                {"type": "null"},
+            ]
+        }
+
     def test_with_skip_none(self, api):
         nested_fields = api.model("NestedModel", {"name": fields.String})
         field = fields.Nested(nested_fields, skip_none=True)


### PR DESCRIPTION
Closes #638

A fix to allow fields.Nested to be nullable in input validation. 