### PR TITLE
Enable using api.parser(trim=True)

### DIFF
--- a/flask_restx/namespace.py
+++ b/flask_restx/namespace.py
@@ -230,9 +230,9 @@ class Namespace(object):
             expect.append(param)
         return self.doc(**params)
 
-    def parser(self):
+    def parser(self, **kwargs):
         """Instanciate a :class:`~RequestParser`"""
-        return RequestParser()
+        return RequestParser(**kwargs)
 
     def as_list(self, field):
         """Allow to specify nested lists for documentation"""

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -175,6 +175,6 @@ class NamespaceTest(object):
 
         resp = client.post_json("/apples/validation/", data, status=400)
         assert re.match(
-            "Additional properties are not allowed \(u*'agge' was unexpected\)",
+            r"Additional properties are not allowed \(u*'agge' was unexpected\)",
             resp["errors"][""],
         )

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -18,6 +18,11 @@ class ReqParseTest(object):
         parser = api.parser()
         assert isinstance(parser, RequestParser)
 
+    def test_api_shortcut_kwargs(self, app):
+        api = Api(app)
+        parser = api.parser(trim=True)
+        assert parser.trim == True
+
     def test_parse_model(self, app):
         model = Model("Todo", {"task": fields.String(required=True)})
 


### PR DESCRIPTION
The `Namespace.parser` shortcut is quite useful, but does not allow using different RequestParser kwargs than the default values currently. In some cases, I think doing `api.parser(trim=True)`  would be cleaner than separately importing RequestParser to access this functionality.

I am suggesting a mini change to enable just that, which is fully backwards-compatible.

# 🐍 🤹‍♂️ 