### PR TITLE
Replace importlib_resources with stdlib

### DIFF
--- a/flask_restx/schemas/__init__.py
+++ b/flask_restx/schemas/__init__.py
@@ -5,10 +5,9 @@ and allows to validate specs against them.
 .. versionadded:: 0.12.1
 """
 
+import importlib.resources
 import io
 import json
-
-import importlib_resources
 
 from collections.abc import Mapping
 from jsonschema import Draft4Validator
@@ -58,7 +57,7 @@ class LazySchema(Mapping):
 
     def _load(self):
         if not self._schema:
-            ref = importlib_resources.files(__name__) / self.filename
+            ref = importlib.resources.files(__name__) / self.filename
 
             with io.open(ref) as infile:
                 self._schema = json.load(infile)

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -3,4 +3,3 @@ jsonschema
 referencing
 Flask>=0.8, !=2.0.0
 werkzeug!=2.0.0
-importlib_resources


### PR DESCRIPTION
Now that Python 3.9 is the minimum version supported, we can switch to using the stdlib importlib.resources, and drop one external dependency.